### PR TITLE
fix: reduce WebSocket polling interval to prevent race condition

### DIFF
--- a/src/gadgets/igSocket.tsx
+++ b/src/gadgets/igSocket.tsx
@@ -182,7 +182,7 @@ const usePortForward = (url: string | null): PortForwardState => {
           clearTimeout(timeoutId);
           resolve(socket);
         } else if (mountedRef.current) {
-          setTimeout(checkSocket, 100);
+          setTimeout(checkSocket, 10);
         } else {
           clearTimeout(timeoutId);
           reject(new Error('Component unmounted while waiting for socket'));


### PR DESCRIPTION
The WASM wrapper's onopen handler was not being triggered on some Kubernetes clusters due to a timing race condition. With 100ms polling, the socket could transition to OPEN state between checks, causing the native onopen event to fire before the WASM wrapper was attached.

Reducing the interval to 10ms ensures the socket is detected while still in CONNECTING state, allowing the WASM wrapper to properly receive the onopen event and initialize the protocol handshake.

Fixes: #19 