### PR TITLE
ci: add automated validation workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: PR Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  validate:
+    name: Lint, Test, and Build
+    runs-on: ubuntu-latest
+    
+    defaults:
+      run:
+        working-directory: ./
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.X
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Linter
+        run: npm run lint
+
+      - name: Run TypeScript Compiler
+        run: npm run tsc
+
+      - name: Run Tests
+        run: npm run test
+
+      - name: Build WebAssembly Plugin
+        run: npm run build


### PR DESCRIPTION
### What this PR does
The repository currently lacks automated CI validation on pull requests. While `package.json` contains `lint`, `tsc`, `test`, and `build` scripts, they require manual developer execution.

This PR adds a `ci.yaml` GitHub Action that automatically triggers on `pull_request` and `push` to `main`. It runs the full Node.js validation matrix (`npm ci`, `lint`, `tsc`, `test`, `build`) using `ubuntu-latest` and Node.js `22.X` (matching the release environment). This prevents formatting errors or broken builds from silently merging into the main branch.

Signed-off-by: Jayadeep Gowda <jayadeepgowda24@gogle.com>
