### PR TITLE
feat: Add input validation and sanitization for Gadget Image URLs

### DIFF
--- a/src/common/helpers.tsx
+++ b/src/common/helpers.tsx
@@ -43,13 +43,9 @@ export function updateInstanceFromStorage(
   return null;
 }
 
-export function testOCIRegex(imageURL: string): boolean {
-  const ociRegex =
+export function isValidOCIImageReference(imageURL: string): boolean {
+  const ociImageReferenceRegex =
     /^([a-z0-9]+(?:[._-][a-z0-9]+)*\.[a-z]{2,}(?::[0-9]+)?\/)?[a-z0-9]+(?:[._\/-][a-z0-9]+)*(?::[a-z0-9.-]+|@[a-z0-9]+:[a-f0-9]+)?$/i;
 
-  if (!ociRegex.test(imageURL)) {
-    return false;
-  }
-
-  return true;
+  return ociImageReferenceRegex.test(imageURL);
 }

--- a/src/common/helpers.tsx
+++ b/src/common/helpers.tsx
@@ -44,8 +44,13 @@ export function updateInstanceFromStorage(
 }
 
 export function isValidOCIImageReference(imageURL: string): boolean {
+  const trimmed = imageURL.trim();
   const ociImageReferenceRegex =
-    /^([a-z0-9]+(?:[._-][a-z0-9]+)*\.[a-z]{2,}(?::[0-9]+)?\/)?[a-z0-9]+(?:[._\/-][a-z0-9]+)*(?::[a-z0-9.-]+|@[a-z0-9]+:[a-f0-9]+)?$/i;
+    /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)[a-z0-9]+(?:[._/-][a-z0-9]+)*(?::[a-z0-9._-]+)?$/;
 
-  return ociImageReferenceRegex.test(imageURL);
+  if (!ociImageReferenceRegex.test(trimmed)) {
+    return false;
+  }
+
+  return trimmed.includes('/gadget/');
 }

--- a/src/common/helpers.tsx
+++ b/src/common/helpers.tsx
@@ -48,9 +48,9 @@ export function isValidOCIImageReference(imageURL: string): boolean {
   const ociImageReferenceRegex =
     /^(?:[a-z0-9.-]+(?::[0-9]+)?\/)[a-z0-9]+(?:[._/-][a-z0-9]+)*(?::[a-z0-9._-]+)?$/;
 
-  if (!ociImageReferenceRegex.test(trimmed)) {
-    return false;
-  }
+  return ociImageReferenceRegex.test(trimmed);
+}
 
-  return trimmed.includes('/gadget/');
+export function isValidGadgetImageReference(imageURL: string): boolean {
+  return imageURL.includes('/gadget/');
 }

--- a/src/common/helpers.tsx
+++ b/src/common/helpers.tsx
@@ -42,3 +42,14 @@ export function updateInstanceFromStorage(
 
   return null;
 }
+
+export function testOCIRegex(imageURL: string): boolean {
+  const ociRegex =
+    /^([a-z0-9]+(?:[._-][a-z0-9]+)*\.[a-z]{2,}(?::[0-9]+)?\/)?[a-z0-9]+(?:[._\/-][a-z0-9]+)*(?::[a-z0-9.-]+|@[a-z0-9]+:[a-f0-9]+)?$/i;
+
+  if (!ociRegex.test(imageURL)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/gadgets/gadgetGrid.tsx
+++ b/src/gadgets/gadgetGrid.tsx
@@ -503,11 +503,7 @@ function CreateGadgetInstance({ gadgetInfo, resource, imageName, enableEmbed = f
   );
 }
 
-const GadgetGrid = ({
-  gadgets,
-  onEmbedClick,
-  resource = null,
-}) => {
+const GadgetGrid = ({ gadgets, onEmbedClick, resource = null }) => {
   if (gadgets.length === 0) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100%">

--- a/src/gadgets/gadgetInput.tsx
+++ b/src/gadgets/gadgetInput.tsx
@@ -61,7 +61,7 @@ export function GadgetInput({ resource, onAddGadget }) {
     localStorage.setItem('headlamp_embeded_resources', JSON.stringify(instances));
     if (resource) {
       onAddGadget(row);
-      enqueueSnackbar(`Added gadget ${imageURL}`, {
+      enqueueSnackbar(`Added gadget ${trimmedURL}`, {
         variant: 'success',
       });
       setImageURL('');
@@ -91,7 +91,7 @@ export function GadgetInput({ resource, onAddGadget }) {
           startIcon={<Icon icon="mdi:plus" />}
           onClick={() => handleRun()}
           sx={{ ml: 2 }}
-          disabled={!imageURL}
+          disabled={!imageURL.trim()}
         >
           Add
         </Button>

--- a/src/gadgets/gadgetInput.tsx
+++ b/src/gadgets/gadgetInput.tsx
@@ -4,7 +4,7 @@ import { Box, Button, TextField } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { generateRandomString, testOCIRegex } from '../common/helpers';
+import { generateRandomString, isValidOCIImageReference } from '../common/helpers';
 
 export function GadgetInput({ resource, onAddGadget }) {
   const [imageURL, setImageURL] = useState('');
@@ -18,7 +18,7 @@ export function GadgetInput({ resource, onAddGadget }) {
       return;
     }
 
-    const isOCIValid = testOCIRegex(trimmedURL);
+    const isOCIValid = isValidOCIImageReference(trimmedURL);
     if (!isOCIValid) {
       enqueueSnackbar(
         'Invalid format. Example: ghcr.io/inspektor-gadget/gadget/trace_open:latest',

--- a/src/gadgets/gadgetInput.tsx
+++ b/src/gadgets/gadgetInput.tsx
@@ -4,7 +4,11 @@ import { Box, Button, TextField } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { generateRandomString, isValidOCIImageReference } from '../common/helpers';
+import {
+  generateRandomString,
+  isValidOCIImageReference,
+  isValidGadgetImageReference,
+} from '../common/helpers';
 
 export function GadgetInput({ resource, onAddGadget }) {
   const [imageURL, setImageURL] = useState('');
@@ -18,10 +22,17 @@ export function GadgetInput({ resource, onAddGadget }) {
       return;
     }
 
-    const isOCIValid = isValidOCIImageReference(trimmedURL);
-    if (!isOCIValid) {
+    if (!isValidOCIImageReference(trimmedURL)) {
       enqueueSnackbar(
-        'Invalid format. Example: ghcr.io/inspektor-gadget/gadget/trace_open:latest',
+        'Invalid OCI image reference. Example: ghcr.io/inspektor-gadget/gadget/trace_open:latest',
+        { variant: 'error' }
+      );
+      return;
+    }
+
+    if (!isValidGadgetImageReference(trimmedURL)) {
+      enqueueSnackbar(
+        'Only Inspektor Gadget OCI images are supported. Example: ghcr.io/inspektor-gadget/gadget/trace_open:latest',
         { variant: 'error' }
       );
       return;

--- a/src/gadgets/gadgetInput.tsx
+++ b/src/gadgets/gadgetInput.tsx
@@ -2,17 +2,33 @@ import { Icon } from '@iconify/react';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Button, TextField } from '@mui/material';
 import { useSnackbar } from 'notistack';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { generateRandomString } from '../common/helpers';
+import { generateRandomString, testOCIRegex } from '../common/helpers';
 
 export function GadgetInput({ resource, onAddGadget }) {
   const [imageURL, setImageURL] = useState('');
   const history = useHistory();
   const { enqueueSnackbar } = useSnackbar();
-  const encodedImageURL = encodeURIComponent(imageURL);
 
   const handleRun = () => {
+    const trimmedURL = imageURL.trim();
+    if (!trimmedURL) {
+      enqueueSnackbar('Image URL cannot be empty', { variant: 'error' });
+      return;
+    }
+
+    const isOCIValid = testOCIRegex(trimmedURL);
+    if (!isOCIValid) {
+      enqueueSnackbar(
+        'Invalid format. Example: ghcr.io/inspektor-gadget/gadget/trace_open:latest',
+        { variant: 'error' }
+      );
+      return;
+    }
+
+    const encodedImageURL = encodeURIComponent(trimmedURL);
+
     const row: {
       id: string;
       isHeadless: boolean;
@@ -59,10 +75,9 @@ export function GadgetInput({ resource, onAddGadget }) {
 
   return (
     <Box mt={2} display="flex" alignItems="center">
-        
       <TextField
         label="Gadget Image URL"
-        placeholder='ghcr.io/inspektor-gadget/gadget/trace_open:latest'
+        placeholder="ghcr.io/inspektor-gadget/gadget/trace_open:latest"
         variant="outlined"
         size="small"
         fullWidth

--- a/src/gadgets/gadgetcreationinresource.tsx
+++ b/src/gadgets/gadgetcreationinresource.tsx
@@ -39,12 +39,12 @@ export function GadgetCreation({ resource, open, setOpen }) {
               <Icon icon="mdi:close" />
             </IconButton>
           </Box>
-            <Box sx={{ mb:8, display: 'flex', flexDirection: 'column', gap: 1 }}>
-              <Typography variant="caption" sx={{ fontSize: '1rem' }}>
-                Enter a gadget image URL or discover gadgets from ArtifactHub
-              </Typography>
-              <GadgetInput resource={''} onAddGadget={() => {}} />
-            </Box>
+          <Box sx={{ mb: 8, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Typography variant="caption" sx={{ fontSize: '1rem' }}>
+              Enter a gadget image URL or discover gadgets from ArtifactHub
+            </Typography>
+            <GadgetInput resource={''} onAddGadget={() => {}} />
+          </Box>
           <Box sx={{ overflow: 'auto', flexGrow: 1 }}>
             <GadgetGrid
               resource={resource}

--- a/src/gadgets/index.tsx
+++ b/src/gadgets/index.tsx
@@ -45,7 +45,7 @@ function GadgetRendererWithTabs() {
       <SectionBox title="Gadgets (beta)">
         <Box sx={{ width: '100%', typography: 'body1', my: 2 }}>
           <Box>
-            <Box sx={{ mb:8, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ mb: 8, display: 'flex', flexDirection: 'column', gap: 1 }}>
               <Typography variant="caption" sx={{ fontSize: '1rem' }}>
                 Enter a gadget image URL or discover gadgets from ArtifactHub
               </Typography>


### PR DESCRIPTION
# feat: Add input validation and sanitization for Gadget Image URLs

This PR introduces input sanitization and validation for the GadgetInput component. Previously, the input field accepted any string including empty spaces or malformed URLs (like https://...) which led to broken navigation routes and "zombie" entries in the local storage.

Fixes #46 

## How to use

- Navigate to the Gadget input section in the Headlamp UI.

- Try to add a gadget by typing only spaces or an invalid URL like https://ghcr.io/trace_open.

- Observe the error snackbar preventing the action.

- Paste a valid URL with accidental leading/trailing spaces (e.g.,  ghcr.io/inspektor-gadget/gadget/trace_open:latest ).

- Click Add and verify the gadget is added correctly without the extra spaces.

## Videos

[Screencast from 2026-03-01 23-43-14.webm](https://github.com/user-attachments/assets/a7e68b03-bbe5-4f4c-9b01-80248a8ff94d)

