### PR TITLE
test: add tests for NotFound component

### DIFF
--- a/src/common/NotFound/index.test.tsx
+++ b/src/common/NotFound/index.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { IGNotFound } from './index';
+
+afterEach(() => {
+    cleanup();
+});
+
+vi.mock('@mui/material', async (importOriginal) => {
+    const actual = await importOriginal<any>();
+    return {
+        ...actual,
+        useTheme: () => ({
+            palette: {
+                background: {
+                    paper: '#ffffff',
+                },
+            },
+        }),
+    };
+});
+
+describe('IGNotFound component', () => {
+    it('renders the not found message without crashing', () => {
+        render(<IGNotFound />);
+        expect(screen.getByText('Inspektor Gadget is not installed')).toBeDefined();
+    });
+
+    it('renders the installation guide link with correct URL and attributes', () => {
+        render(<IGNotFound />);
+        const linkElement = screen.getByRole('link', { name: /installation guide/i });
+        expect(linkElement).toBeDefined();
+        expect(linkElement.getAttribute('href')).toBe('https://inspektor-gadget.io/docs/latest/quick-start');
+        expect(linkElement.getAttribute('target')).toBe('_blank');
+    });
+
+    it('renders the correct heading', () => {
+        render(<IGNotFound />);
+        const headingElement = screen.getByRole('heading', { level: 1 });
+        expect(headingElement).toBeDefined();
+        expect(headingElement.textContent).toBe('Inspektor Gadget is not installed');
+    });
+});


### PR DESCRIPTION
# Add tests for the NotFound component

ref #20

This PR adds a test file for the `NotFound` component located in `src/common/NotFound/index.tsx`.

The test verifies that the component renders correctly and that the expected fallback UI is displayed when the component is mounted. The tests follow the project's existing testing patterns using React Testing Library and aim to improve overall test coverage of the repository.

## How to use

Reviewers can validate this PR by running the test suite locally and confirming that the newly added test executes successfully.

Steps:

1. Checkout this branch.
2. Install dependencies if needed.
3. Run the test suite.

## Testing done

Commands executed:

npm install
npm test

Result:

<img width="823" height="348" alt="Screenshot 2026-03-07 at 10 32 04 PM" src="https://github.com/user-attachments/assets/4c08f0f4-4b46-458c-83be-7945483793ab" />


All tests passed successfully and the new test file `src/common/NotFound/index.test.tsx` executed without errors.
