### PR TITLE
Replace Static "Not Installed" Message with Installation Diagnostics Panel

### DIFF
--- a/src/common/GadgetContext/index.tsx
+++ b/src/common/GadgetContext/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { createContext } from 'react';
-import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 import { AllColumnMeta, getSortedColumns } from '../../gadgets/utility';
+import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 
 // Create a context for sharing gadget-related state
 export const GadgetContext = createContext(null);

--- a/src/common/InstallationStatus/checks.ts
+++ b/src/common/InstallationStatus/checks.ts
@@ -1,3 +1,5 @@
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from '../../gadgets/helper';
+
 export type CheckStatus = 'pass' | 'warn' | 'fail' | 'loading';
 
 export interface CheckResult {
@@ -9,8 +11,8 @@ export interface CheckResult {
 }
 
 export const IG_NAMESPACE = 'gadget';
-export const IG_DAEMONSET_LABEL_KEY = 'k8s-app';
-export const IG_DAEMONSET_LABEL_VALUE = 'gadget';
+export const IG_DAEMONSET_LABEL_KEY = IG_CONTAINER_KEY;
+export const IG_DAEMONSET_LABEL_VALUE = IG_CONTAINER_VALUE;
 
 export function checkNamespace(namespaces: any[] | null): CheckResult {
   if (namespaces === null) {
@@ -53,8 +55,13 @@ export function checkDaemonSet(daemonSets: any[] | null): CheckResult {
   }
 
   const ds = daemonSets.find(d => {
-    const labels = d.jsonData?.metadata?.labels || d.metadata?.labels || {};
-    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE;
+    const meta = d.jsonData || d;
+    const metadataLabels = meta?.metadata?.labels || {};
+    const selectorLabels = meta?.spec?.selector?.matchLabels || {};
+    return (
+      metadataLabels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE ||
+      selectorLabels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE
+    );
   });
 
   if (!ds) {
@@ -218,12 +225,14 @@ export function checkNodeCoverage(pods: any[] | null, nodes: any[] | null): Chec
   }
 
   const schedulableNodes = nodes.filter(node => {
-    const spec = node.jsonData?.spec || node.spec || {};
+    const nodeData = node.jsonData || node;
+    const spec = nodeData.spec || {};
     const taints = spec.taints || [];
     if (spec.unschedulable === true) return false;
-    return !taints.some(
-      (t: any) => t.effect === 'NoSchedule' && t.key === 'node.kubernetes.io/unschedulable'
-    );
+    if (taints.some((t: any) => t.effect === 'NoSchedule')) return false;
+    const conditions: any[] = nodeData.status?.conditions || [];
+    const readyCondition = conditions.find((c: any) => c.type === 'Ready');
+    return readyCondition?.status === 'True';
   });
 
   const igPods = pods.filter(pod => {
@@ -308,7 +317,13 @@ export function formatDiagnostics(checks: CheckResult[]): string {
   ];
 
   for (const check of checks) {
-    const icon = check.status === 'pass' ? 'PASS' : check.status === 'warn' ? 'WARN' : 'FAIL';
+    const statusMap: Record<CheckStatus, string> = {
+      pass: 'PASS',
+      warn: 'WARN',
+      fail: 'FAIL',
+      loading: 'LOAD',
+    };
+    const icon = statusMap[check.status] ?? 'FAIL';
     lines.push(`[${icon}] ${check.name}: ${check.message}`);
     if (check.details) {
       lines.push(`       Details: ${check.details}`);

--- a/src/common/InstallationStatus/checks.ts
+++ b/src/common/InstallationStatus/checks.ts
@@ -1,0 +1,314 @@
+export type CheckStatus = 'pass' | 'warn' | 'fail' | 'loading';
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+  details?: string;
+  docsHint?: string;
+}
+
+export const IG_NAMESPACE = 'gadget';
+export const IG_DAEMONSET_LABEL_KEY = 'k8s-app';
+export const IG_DAEMONSET_LABEL_VALUE = 'gadget';
+
+export function checkNamespace(namespaces: any[] | null): CheckResult {
+  if (namespaces === null) {
+    return {
+      name: 'Namespace',
+      status: 'loading',
+      message: 'Checking for gadget namespace...',
+    };
+  }
+
+  const found = namespaces.some(
+    ns => ns.jsonData?.metadata?.name === IG_NAMESPACE || ns.metadata?.name === IG_NAMESPACE
+  );
+
+  if (found) {
+    return {
+      name: 'Namespace',
+      status: 'pass',
+      message: `Namespace "${IG_NAMESPACE}" exists.`,
+    };
+  }
+
+  return {
+    name: 'Namespace',
+    status: 'fail',
+    message: `Namespace "${IG_NAMESPACE}" not found.`,
+    details:
+      'Inspektor Gadget requires the "gadget" namespace. This usually means Inspektor Gadget has not been installed yet.',
+    docsHint: 'Install Inspektor Gadget using Helm or kubectl to create the required namespace.',
+  };
+}
+
+export function checkDaemonSet(daemonSets: any[] | null): CheckResult {
+  if (daemonSets === null) {
+    return {
+      name: 'DaemonSet',
+      status: 'loading',
+      message: 'Checking for gadget DaemonSet...',
+    };
+  }
+
+  const ds = daemonSets.find(d => {
+    const labels = d.jsonData?.metadata?.labels || d.metadata?.labels || {};
+    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE;
+  });
+
+  if (!ds) {
+    return {
+      name: 'DaemonSet',
+      status: 'fail',
+      message: 'Inspektor Gadget DaemonSet not found in the gadget namespace.',
+      details:
+        'The Inspektor Gadget DaemonSet is responsible for running gadget pods on each node. Without it, no gadgets can execute.',
+      docsHint: 'Re-install Inspektor Gadget to create the DaemonSet.',
+    };
+  }
+  const status = ds.jsonData?.status || ds.status || {};
+  const desired = status.desiredNumberScheduled ?? 0;
+  const ready = status.numberReady ?? 0;
+  const unavailable = status.numberUnavailable ?? 0;
+
+  if (desired === 0) {
+    return {
+      name: 'DaemonSet',
+      status: 'warn',
+      message: 'DaemonSet found but desired replicas is 0.',
+      details: 'The DaemonSet exists but is not scheduling any pods. Check node selectors or taints.',
+    };
+  }
+
+  if (ready === desired) {
+    return {
+      name: 'DaemonSet',
+      status: 'pass',
+      message: `DaemonSet healthy: ${ready}/${desired} replicas ready.`,
+    };
+  }
+
+  if (ready > 0) {
+    return {
+      name: 'DaemonSet',
+      status: 'warn',
+      message: `DaemonSet partially ready: ${ready}/${desired} replicas (${unavailable} unavailable).`,
+      details:
+        'Some nodes are not running the Inspektor Gadget pod. Gadgets will not capture events from those nodes.',
+      docsHint: 'Check node taints, resource limits, or scheduling constraints.',
+    };
+  }
+
+  return {
+    name: 'DaemonSet',
+    status: 'fail',
+    message: `DaemonSet found but 0/${desired} replicas ready.`,
+    details:
+      'The DaemonSet exists but no pods are running. Check pod events and logs for errors.',
+    docsHint: 'Run "kubectl describe ds -n gadget" to see scheduling failures.',
+  };
+}
+
+export function checkPodHealth(pods: any[] | null): CheckResult {
+  if (pods === null) {
+    return {
+      name: 'Pod Health',
+      status: 'loading',
+      message: 'Checking gadget pod health...',
+    };
+  }
+
+  const igPods = pods.filter(pod => {
+    const labels = pod.jsonData?.metadata?.labels || pod.metadata?.labels || {};
+    const namespace = pod.jsonData?.metadata?.namespace || pod.metadata?.namespace;
+    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE;
+  });
+
+  if (igPods.length === 0) {
+    return {
+      name: 'Pod Health',
+      status: 'fail',
+      message: 'No gadget pods found.',
+      details: `No pods with label k8s-app=gadget were found in the "${IG_NAMESPACE}" namespace.`,
+    };
+  }
+
+  const podStatuses: string[] = [];
+  let crashingCount = 0;
+  let pendingCount = 0;
+  let runningCount = 0;
+
+  for (const pod of igPods) {
+    const podData = pod.jsonData || pod;
+    const phase = podData.status?.phase || 'Unknown';
+    const containerStatuses = podData.status?.containerStatuses || [];
+
+    const isCrashing = containerStatuses.some(
+      (cs: any) =>
+        cs.state?.waiting?.reason === 'CrashLoopBackOff' ||
+        cs.state?.waiting?.reason === 'ImagePullBackOff' ||
+        cs.state?.waiting?.reason === 'ErrImagePull'
+    );
+
+    if (isCrashing) {
+      const reason =
+        containerStatuses.find(
+          (cs: any) =>
+            cs.state?.waiting?.reason === 'CrashLoopBackOff' ||
+            cs.state?.waiting?.reason === 'ImagePullBackOff' ||
+            cs.state?.waiting?.reason === 'ErrImagePull'
+        )?.state?.waiting?.reason || 'Unknown';
+      podStatuses.push(
+        `${podData.metadata?.name || 'unknown'}: ${reason}`
+      );
+      crashingCount++;
+    } else if (phase === 'Pending') {
+      podStatuses.push(`${podData.metadata?.name || 'unknown'}: Pending`);
+      pendingCount++;
+    } else if (phase === 'Running') {
+      runningCount++;
+    }
+  }
+
+  if (crashingCount > 0) {
+    return {
+      name: 'Pod Health',
+      status: 'fail',
+      message: `${crashingCount}/${igPods.length} gadget pod(s) are failing.`,
+      details: podStatuses.join('\n'),
+      docsHint:
+        'Check pod logs with "kubectl logs -n gadget <pod-name>". Common causes: missing BTF support, incompatible kernel version, or image pull errors.',
+    };
+  }
+
+  if (pendingCount > 0) {
+    return {
+      name: 'Pod Health',
+      status: 'warn',
+      message: `${pendingCount}/${igPods.length} gadget pod(s) are pending.`,
+      details: podStatuses.join('\n'),
+      docsHint: 'Check node resources and scheduling constraints.',
+    };
+  }
+
+  if (runningCount === igPods.length) {
+    return {
+      name: 'Pod Health',
+      status: 'pass',
+      message: `All ${runningCount} gadget pod(s) are running.`,
+    };
+  }
+
+  return {
+    name: 'Pod Health',
+    status: 'warn',
+    message: `${runningCount}/${igPods.length} gadget pod(s) running.`,
+    details: podStatuses.length > 0 ? podStatuses.join('\n') : undefined,
+  };
+}
+
+export function checkNodeCoverage(pods: any[] | null, nodes: any[] | null): CheckResult {
+  if (pods === null || nodes === null) {
+    return {
+      name: 'Node Coverage',
+      status: 'loading',
+      message: 'Checking node coverage...',
+    };
+  }
+
+  const schedulableNodes = nodes.filter(node => {
+    const spec = node.jsonData?.spec || node.spec || {};
+    const taints = spec.taints || [];
+    if (spec.unschedulable === true) return false;
+    return !taints.some((t: any) => t.effect === 'NoSchedule' && t.key === 'node.kubernetes.io/unschedulable');
+  });
+
+  const igPods = pods.filter(pod => {
+    const labels = pod.jsonData?.metadata?.labels || pod.metadata?.labels || {};
+    const namespace = pod.jsonData?.metadata?.namespace || pod.metadata?.namespace;
+    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE;
+  });
+
+  const coveredNodes = new Set(
+    igPods
+      .filter(pod => {
+        const phase = (pod.jsonData || pod).status?.phase;
+        return phase === 'Running';
+      })
+      .map(pod => (pod.jsonData || pod).spec?.nodeName)
+      .filter(Boolean)
+  );
+
+  const totalSchedulable = schedulableNodes.length;
+  const covered = coveredNodes.size;
+
+  if (totalSchedulable === 0) {
+    return {
+      name: 'Node Coverage',
+      status: 'warn',
+      message: 'No schedulable nodes found.',
+    };
+  }
+
+  if (covered === totalSchedulable) {
+    return {
+      name: 'Node Coverage',
+      status: 'pass',
+      message: `All ${totalSchedulable} schedulable node(s) covered.`,
+    };
+  }
+
+  if (covered > 0) {
+    const uncoveredNames = schedulableNodes
+      .filter(n => {
+        const name = n.jsonData?.metadata?.name || n.metadata?.name;
+        return !coveredNodes.has(name);
+      })
+      .map(n => n.jsonData?.metadata?.name || n.metadata?.name);
+
+    return {
+      name: 'Node Coverage',
+      status: 'warn',
+      message: `${covered}/${totalSchedulable} nodes covered. Missing: ${uncoveredNames.join(', ')}`,
+      details:
+        'Gadgets will not capture events from uncovered nodes. This may cause blind spots in observability.',
+      docsHint: 'Check DaemonSet tolerations and node taints.',
+    };
+  }
+
+  return {
+    name: 'Node Coverage',
+    status: 'fail',
+    message: 'No nodes are running a gadget pod.',
+    details: `0/${totalSchedulable} schedulable nodes have a running gadget pod.`,
+  };
+}
+
+export function getOverallStatus(checks: CheckResult[]): 'healthy' | 'degraded' | 'failed' | 'loading' {
+  if (checks.some(c => c.status === 'loading')) return 'loading';
+  if (checks.every(c => c.status === 'pass')) return 'healthy';
+  if (checks.some(c => c.status === 'fail')) return 'failed';
+  return 'degraded';
+}
+
+export function formatDiagnostics(checks: CheckResult[]): string {
+  const lines = [
+    'Inspektor Gadget Plugin - Installation Diagnostics',
+    `Timestamp: ${new Date().toISOString()}`,
+    '---',
+  ];
+
+  for (const check of checks) {
+    const icon = check.status === 'pass' ? 'PASS' : check.status === 'warn' ? 'WARN' : 'FAIL';
+    lines.push(`[${icon}] ${check.name}: ${check.message}`);
+    if (check.details) {
+      lines.push(`       Details: ${check.details}`);
+    }
+    if (check.docsHint) {
+      lines.push(`       Hint: ${check.docsHint}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/common/InstallationStatus/checks.ts
+++ b/src/common/InstallationStatus/checks.ts
@@ -77,7 +77,8 @@ export function checkDaemonSet(daemonSets: any[] | null): CheckResult {
       name: 'DaemonSet',
       status: 'warn',
       message: 'DaemonSet found but desired replicas is 0.',
-      details: 'The DaemonSet exists but is not scheduling any pods. Check node selectors or taints.',
+      details:
+        'The DaemonSet exists but is not scheduling any pods. Check node selectors or taints.',
     };
   }
 
@@ -104,8 +105,7 @@ export function checkDaemonSet(daemonSets: any[] | null): CheckResult {
     name: 'DaemonSet',
     status: 'fail',
     message: `DaemonSet found but 0/${desired} replicas ready.`,
-    details:
-      'The DaemonSet exists but no pods are running. Check pod events and logs for errors.',
+    details: 'The DaemonSet exists but no pods are running. Check pod events and logs for errors.',
     docsHint: 'Run "kubectl describe ds -n gadget" to see scheduling failures.',
   };
 }
@@ -122,7 +122,9 @@ export function checkPodHealth(pods: any[] | null): CheckResult {
   const igPods = pods.filter(pod => {
     const labels = pod.jsonData?.metadata?.labels || pod.metadata?.labels || {};
     const namespace = pod.jsonData?.metadata?.namespace || pod.metadata?.namespace;
-    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE;
+    return (
+      labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE
+    );
   });
 
   if (igPods.length === 0) {
@@ -159,9 +161,7 @@ export function checkPodHealth(pods: any[] | null): CheckResult {
             cs.state?.waiting?.reason === 'ImagePullBackOff' ||
             cs.state?.waiting?.reason === 'ErrImagePull'
         )?.state?.waiting?.reason || 'Unknown';
-      podStatuses.push(
-        `${podData.metadata?.name || 'unknown'}: ${reason}`
-      );
+      podStatuses.push(`${podData.metadata?.name || 'unknown'}: ${reason}`);
       crashingCount++;
     } else if (phase === 'Pending') {
       podStatuses.push(`${podData.metadata?.name || 'unknown'}: Pending`);
@@ -221,13 +221,17 @@ export function checkNodeCoverage(pods: any[] | null, nodes: any[] | null): Chec
     const spec = node.jsonData?.spec || node.spec || {};
     const taints = spec.taints || [];
     if (spec.unschedulable === true) return false;
-    return !taints.some((t: any) => t.effect === 'NoSchedule' && t.key === 'node.kubernetes.io/unschedulable');
+    return !taints.some(
+      (t: any) => t.effect === 'NoSchedule' && t.key === 'node.kubernetes.io/unschedulable'
+    );
   });
 
   const igPods = pods.filter(pod => {
     const labels = pod.jsonData?.metadata?.labels || pod.metadata?.labels || {};
     const namespace = pod.jsonData?.metadata?.namespace || pod.metadata?.namespace;
-    return labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE;
+    return (
+      labels[IG_DAEMONSET_LABEL_KEY] === IG_DAEMONSET_LABEL_VALUE && namespace === IG_NAMESPACE
+    );
   });
 
   const coveredNodes = new Set(
@@ -270,7 +274,9 @@ export function checkNodeCoverage(pods: any[] | null, nodes: any[] | null): Chec
     return {
       name: 'Node Coverage',
       status: 'warn',
-      message: `${covered}/${totalSchedulable} nodes covered. Missing: ${uncoveredNames.join(', ')}`,
+      message: `${covered}/${totalSchedulable} nodes covered. Missing: ${uncoveredNames.join(
+        ', '
+      )}`,
       details:
         'Gadgets will not capture events from uncovered nodes. This may cause blind spots in observability.',
       docsHint: 'Check DaemonSet tolerations and node taints.',
@@ -285,7 +291,9 @@ export function checkNodeCoverage(pods: any[] | null, nodes: any[] | null): Chec
   };
 }
 
-export function getOverallStatus(checks: CheckResult[]): 'healthy' | 'degraded' | 'failed' | 'loading' {
+export function getOverallStatus(
+  checks: CheckResult[]
+): 'healthy' | 'degraded' | 'failed' | 'loading' {
   if (checks.some(c => c.status === 'loading')) return 'loading';
   if (checks.every(c => c.status === 'pass')) return 'healthy';
   if (checks.some(c => c.status === 'fail')) return 'failed';

--- a/src/common/InstallationStatus/index.tsx
+++ b/src/common/InstallationStatus/index.tsx
@@ -1,0 +1,283 @@
+import { Icon } from '@iconify/react';
+import { Loader, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
+import K8s from '@kinvolk/headlamp-plugin/lib/k8s';
+import {
+  Alert,
+  Box,
+  Button,
+  Collapse,
+  Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Snackbar,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  checkDaemonSet,
+  checkNamespace,
+  checkNodeCoverage,
+  checkPodHealth,
+  CheckResult,
+  CheckStatus,
+  formatDiagnostics,
+  getOverallStatus,
+  IG_NAMESPACE,
+} from './checks';
+
+function StatusIcon({ status }: { status: CheckStatus }) {
+  const theme = useTheme();
+  switch (status) {
+    case 'pass':
+      return <Icon icon="mdi:check-circle" width="24" height="24" color={theme.palette.success.main} />;
+    case 'warn':
+      return <Icon icon="mdi:alert-circle" width="24" height="24" color={theme.palette.warning.main} />;
+    case 'fail':
+      return <Icon icon="mdi:close-circle" width="24" height="24" color={theme.palette.error.main} />;
+    case 'loading':
+      return <Icon icon="mdi:progress-clock" width="24" height="24" color={theme.palette.text.secondary} />;
+    default:
+      return null;
+  }
+}
+
+function CheckItem({ check }: { check: CheckResult }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = check.details || check.docsHint;
+  const theme = useTheme();
+
+  return (
+    <ListItem
+      sx={{
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        py: 1.5,
+      }}
+    >
+      <Box
+        display="flex"
+        alignItems="center"
+        width="100%"
+        sx={{ cursor: hasDetails ? 'pointer' : 'default' }}
+        onClick={() => hasDetails && setExpanded(prev => !prev)}
+        role={hasDetails ? 'button' : undefined}
+        tabIndex={hasDetails ? 0 : undefined}
+        aria-label={`${check.name} check: ${check.status}`}
+        aria-expanded={hasDetails ? expanded : undefined}
+        onKeyDown={e => {
+          if (hasDetails && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            setExpanded(prev => !prev);
+          }
+        }}
+      >
+        <ListItemIcon sx={{ minWidth: 40 }}>
+          <StatusIcon status={check.status} />
+        </ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography variant="subtitle2">{check.name}</Typography>
+          }
+          secondary={check.message}
+        />
+        {hasDetails && (
+          <Icon
+            icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'}
+            width="20"
+            height="20"
+          />
+        )}
+      </Box>
+      {hasDetails && (
+        <Collapse in={expanded} sx={{ width: '100%', pl: 5 }}>
+          <Box mt={1} mb={1}>
+            {check.details && (
+              <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-line', mb: 1 }}>
+                {check.details}
+              </Typography>
+            )}
+            {check.docsHint && (
+              <Alert severity="info" variant="outlined" sx={{ mt: 1 }}>
+                {check.docsHint}
+              </Alert>
+            )}
+          </Box>
+        </Collapse>
+      )}
+    </ListItem>
+  );
+}
+
+function OverallBanner({ status }: { status: ReturnType<typeof getOverallStatus> }) {
+  const theme = useTheme();
+
+  const config: Record<string, { icon: string; color: string; bg: string; text: string }> = {
+    healthy: {
+      icon: 'mdi:check-circle-outline',
+      color: theme.palette.success.main,
+      bg: theme.palette.mode === 'dark' ? 'rgba(46,125,50,0.15)' : 'rgba(46,125,50,0.08)',
+      text: 'Inspektor Gadget is installed and healthy.',
+    },
+    degraded: {
+      icon: 'mdi:alert-outline',
+      color: theme.palette.warning.main,
+      bg: theme.palette.mode === 'dark' ? 'rgba(237,108,2,0.15)' : 'rgba(237,108,2,0.08)',
+      text: 'Inspektor Gadget is partially running. Some checks need attention.',
+    },
+    failed: {
+      icon: 'mdi:close-circle-outline',
+      color: theme.palette.error.main,
+      bg: theme.palette.mode === 'dark' ? 'rgba(211,47,47,0.15)' : 'rgba(211,47,47,0.08)',
+      text: 'Inspektor Gadget installation has issues that must be resolved.',
+    },
+    loading: {
+      icon: 'mdi:progress-clock',
+      color: theme.palette.text.secondary,
+      bg: 'transparent',
+      text: 'Running diagnostic checks...',
+    },
+  };
+
+  const c = config[status] || config.failed;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap={1.5}
+      p={2}
+      mb={2}
+      borderRadius={1}
+      sx={{ backgroundColor: c.bg }}
+    >
+      <Icon icon={c.icon} width="28" height="28" color={c.color} />
+      <Typography variant="subtitle1" sx={{ color: c.color, fontWeight: 600 }}>
+        {c.text}
+      </Typography>
+    </Box>
+  );
+}
+
+export function InstallationStatus() {
+  const [namespaces] = K8s.ResourceClasses.Namespace.useList();
+  const [daemonSets] = K8s.ResourceClasses.DaemonSet.useList({ namespace: IG_NAMESPACE });
+  const [pods] = K8s.ResourceClasses.Pod.useList({ namespace: IG_NAMESPACE });
+  const [nodes] = K8s.ResourceClasses.Node.useList();
+  const [snackOpen, setSnackOpen] = useState(false);
+  const [snackError, setSnackError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+
+  const checks: CheckResult[] = useMemo(
+    () => [
+      checkNamespace(namespaces),
+      checkDaemonSet(daemonSets),
+      checkPodHealth(pods),
+      checkNodeCoverage(pods, nodes),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [namespaces, daemonSets, pods, nodes, retryKey]
+  );
+
+  const overall = useMemo(() => getOverallStatus(checks), [checks]);
+
+  const handleCopyDiagnostics = useCallback(() => {
+    const text = formatDiagnostics(checks);
+    if (!navigator.clipboard?.writeText) {
+      console.error('Clipboard API is not available in this environment.');
+      setSnackError(true);
+      return;
+    }
+    navigator.clipboard.writeText(text)
+      .then(() => setSnackOpen(true))
+      .catch(err => {
+        console.error('Clipboard write failed:', err);
+        setSnackError(true);
+      });
+  }, [checks]);
+
+  const handleRetry = useCallback(() => {
+    setRetryKey(prev => prev + 1);
+  }, []);
+
+  if (overall === 'loading') {
+    return <Loader title="Running installation checks..." />;
+  }
+
+  return (
+    <SectionBox
+      title={
+        <Box display="flex" alignItems="center" gap={1}>
+          <Icon icon="mdi:stethoscope" width="24" height="24" />
+          <Typography variant="h5">Installation Diagnostics</Typography>
+        </Box>
+      }
+    >
+      <Box p={2}>
+        <OverallBanner status={overall} />
+
+        <List disablePadding>
+          {checks.map(check => (
+            <CheckItem key={check.name} check={check} />
+          ))}
+        </List>
+
+        <Box display="flex" gap={2} mt={3} flexWrap="wrap">
+          <Button variant="outlined" size="small" onClick={handleRetry} startIcon={<Icon icon="mdi:refresh" />}>
+            Recalculate
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleCopyDiagnostics}
+            startIcon={<Icon icon="mdi:content-copy" />}
+          >
+            Copy Diagnostics
+          </Button>
+        </Box>
+
+        <Box mt={3} p={2} borderRadius={1} sx={{ backgroundColor: 'action.hover' }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Need help?
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Follow the{' '}
+            <Link
+              target="_blank"
+              href="https://inspektor-gadget.io/docs/latest/quick-start"
+              rel="noopener"
+            >
+              Inspektor Gadget Quick Start Guide
+            </Link>{' '}
+            to install or troubleshoot your deployment. You can also copy the diagnostics above to
+            share with your team or in a{' '}
+            <Link
+              target="_blank"
+              href="https://github.com/inspektor-gadget/inspektor-gadget/issues"
+              rel="noopener"
+            >
+              GitHub issue
+            </Link>
+            .
+          </Typography>
+        </Box>
+      </Box>
+
+      <Snackbar
+        open={snackOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)}
+        message="Diagnostics copied to clipboard"
+      />
+      <Snackbar
+        open={snackError}
+        autoHideDuration={4000}
+        onClose={() => setSnackError(false)}
+        message="Failed to copy diagnostics to clipboard"
+      />
+    </SectionBox>
+  );
+}

--- a/src/common/InstallationStatus/index.tsx
+++ b/src/common/InstallationStatus/index.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import React, { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   checkDaemonSet,
   checkNamespace,
@@ -173,14 +173,13 @@ function OverallBanner({ status }: { status: ReturnType<typeof getOverallStatus>
   );
 }
 
-export function InstallationStatus() {
+function InstallationStatusPanel({ onRetry }: { onRetry: () => void }) {
   const [namespaces] = K8s.ResourceClasses.Namespace.useList();
   const [daemonSets] = K8s.ResourceClasses.DaemonSet.useList({ namespace: IG_NAMESPACE });
   const [pods] = K8s.ResourceClasses.Pod.useList({ namespace: IG_NAMESPACE });
   const [nodes] = K8s.ResourceClasses.Node.useList();
   const [snackOpen, setSnackOpen] = useState(false);
   const [snackError, setSnackError] = useState(false);
-  const [retryKey, setRetryKey] = useState(0);
 
   const checks: CheckResult[] = useMemo(
     () => [
@@ -189,8 +188,7 @@ export function InstallationStatus() {
       checkPodHealth(pods),
       checkNodeCoverage(pods, nodes),
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [namespaces, daemonSets, pods, nodes, retryKey]
+    [namespaces, daemonSets, pods, nodes]
   );
 
   const overall = useMemo(() => getOverallStatus(checks), [checks]);
@@ -210,10 +208,6 @@ export function InstallationStatus() {
         setSnackError(true);
       });
   }, [checks]);
-
-  const handleRetry = useCallback(() => {
-    setRetryKey(prev => prev + 1);
-  }, []);
 
   if (overall === 'loading') {
     return <Loader title="Running installation checks..." />;
@@ -241,10 +235,10 @@ export function InstallationStatus() {
           <Button
             variant="outlined"
             size="small"
-            onClick={handleRetry}
+            onClick={onRetry}
             startIcon={<Icon icon="mdi:refresh" />}
           >
-            Recalculate
+            Re-run Checks
           </Button>
           <Button
             variant="outlined"
@@ -296,5 +290,12 @@ export function InstallationStatus() {
         message="Failed to copy diagnostics to clipboard"
       />
     </SectionBox>
+  );
+}
+
+export function InstallationStatus() {
+  const [retryKey, setRetryKey] = useState(0);
+  return (
+    <InstallationStatusPanel key={retryKey} onRetry={() => setRetryKey(k => k + 1)} />
   );
 }

--- a/src/common/InstallationStatus/index.tsx
+++ b/src/common/InstallationStatus/index.tsx
@@ -32,13 +32,26 @@ function StatusIcon({ status }: { status: CheckStatus }) {
   const theme = useTheme();
   switch (status) {
     case 'pass':
-      return <Icon icon="mdi:check-circle" width="24" height="24" color={theme.palette.success.main} />;
+      return (
+        <Icon icon="mdi:check-circle" width="24" height="24" color={theme.palette.success.main} />
+      );
     case 'warn':
-      return <Icon icon="mdi:alert-circle" width="24" height="24" color={theme.palette.warning.main} />;
+      return (
+        <Icon icon="mdi:alert-circle" width="24" height="24" color={theme.palette.warning.main} />
+      );
     case 'fail':
-      return <Icon icon="mdi:close-circle" width="24" height="24" color={theme.palette.error.main} />;
+      return (
+        <Icon icon="mdi:close-circle" width="24" height="24" color={theme.palette.error.main} />
+      );
     case 'loading':
-      return <Icon icon="mdi:progress-clock" width="24" height="24" color={theme.palette.text.secondary} />;
+      return (
+        <Icon
+          icon="mdi:progress-clock"
+          width="24"
+          height="24"
+          color={theme.palette.text.secondary}
+        />
+      );
     default:
       return null;
   }
@@ -79,24 +92,22 @@ function CheckItem({ check }: { check: CheckResult }) {
           <StatusIcon status={check.status} />
         </ListItemIcon>
         <ListItemText
-          primary={
-            <Typography variant="subtitle2">{check.name}</Typography>
-          }
+          primary={<Typography variant="subtitle2">{check.name}</Typography>}
           secondary={check.message}
         />
         {hasDetails && (
-          <Icon
-            icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'}
-            width="20"
-            height="20"
-          />
+          <Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width="20" height="20" />
         )}
       </Box>
       {hasDetails && (
         <Collapse in={expanded} sx={{ width: '100%', pl: 5 }}>
           <Box mt={1} mb={1}>
             {check.details && (
-              <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-line', mb: 1 }}>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ whiteSpace: 'pre-line', mb: 1 }}
+              >
                 {check.details}
               </Typography>
             )}
@@ -191,7 +202,8 @@ export function InstallationStatus() {
       setSnackError(true);
       return;
     }
-    navigator.clipboard.writeText(text)
+    navigator.clipboard
+      .writeText(text)
       .then(() => setSnackOpen(true))
       .catch(err => {
         console.error('Clipboard write failed:', err);
@@ -226,7 +238,12 @@ export function InstallationStatus() {
         </List>
 
         <Box display="flex" gap={2} mt={3} flexWrap="wrap">
-          <Button variant="outlined" size="small" onClick={handleRetry} startIcon={<Icon icon="mdi:refresh" />}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleRetry}
+            startIcon={<Icon icon="mdi:refresh" />}
+          >
             Recalculate
           </Button>
           <Button

--- a/src/common/InstallationStatus/index.tsx
+++ b/src/common/InstallationStatus/index.tsx
@@ -295,7 +295,5 @@ function InstallationStatusPanel({ onRetry }: { onRetry: () => void }) {
 
 export function InstallationStatus() {
   const [retryKey, setRetryKey] = useState(0);
-  return (
-    <InstallationStatusPanel key={retryKey} onRetry={() => setRetryKey(k => k + 1)} />
-  );
+  return <InstallationStatusPanel key={retryKey} onRetry={() => setRetryKey(k => k + 1)} />;
 }

--- a/src/common/NotFound/index.tsx
+++ b/src/common/NotFound/index.tsx
@@ -1,27 +1,5 @@
-import { Box, Link, useTheme } from '@mui/material';
+import { InstallationStatus } from '../InstallationStatus';
 
 export function IGNotFound() {
-  const theme = useTheme();
-  return (
-    <Box
-      // center this box and also wrap it in a white background with some box shadow
-      style={{
-        padding: '1rem',
-        alignItems: 'center',
-        margin: '2rem auto',
-        height: '20vh',
-        width: '50%',
-        backgroundColor: theme.palette.background.paper,
-      }}
-    >
-      <h1>Inspektor Gadget is not installed</h1>
-      <p>
-        Follow the{' '}
-        <Link target="_blank" href="https://inspektor-gadget.io/docs/latest/quick-start">
-          installation guide
-        </Link>{' '}
-        to install Inspektor Gadget on your cluster
-      </p>
-    </Box>
-  );
+  return <InstallationStatus />;
 }

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -17,7 +17,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { AllColumnMeta, getSortedColumns,processGadgetData } from './utility';
+import { AllColumnMeta, getSortedColumns, processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -17,7 +17,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { AllColumnMeta, processGadgetData, getSortedColumns } from './utility';
+import { AllColumnMeta, getSortedColumns,processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -9,7 +9,10 @@ export type FieldMeta = { type?: string; annotations?: Record<string, string> };
 export type ColumnMeta = Record<string, FieldMeta>;
 export type AllColumnMeta = Record<string, ColumnMeta>;
 
-export function getSortedColumns(columns: string[], annotations?: Record<string, string>): string[] {
+export function getSortedColumns(
+  columns: string[],
+  annotations?: Record<string, string>
+): string[] {
   const preferredOrderStr = annotations?.['columns'];
   if (preferredOrderStr) {
     const preferredOrder = preferredOrderStr.split(',').map(s => s.trim());
@@ -114,12 +117,12 @@ export const processGadgetData = (
   const massagedData: Record<string, any> = columns.includes(IS_METRIC)
     ? data
     : columns.reduce((acc, column) => {
-      const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
-      if (processedValue !== null) {
-        acc[column] = processedValue;
-      }
-      return acc;
-    }, {});
+        const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
+        if (processedValue !== null) {
+          acc[column] = processedValue;
+        }
+        return acc;
+      }, {});
 
   if (columns.includes(IS_METRIC)) {
     setBufferedGadgetData(prevData => ({
@@ -153,7 +156,7 @@ export const createGadgetCallbacks = (
   columnMeta?: AllColumnMeta
 ) => {
   return {
-    onGadgetInfo: prepareGadgetInfo || (() => { }),
+    onGadgetInfo: prepareGadgetInfo || (() => {}),
     onReady: () => setLoading(false),
     onDone: () => setLoading(false),
     onError: (error: any) => console.error('Gadget error:', error),


### PR DESCRIPTION
**Summary**

Right now, if any pod check fails, we just show "Inspektor Gadget is not installed" with a docs link. This is unhelpful because pods could be crashing, stuck in `CrashLoopBackOff`, or partially deployed, but the UI just says "not installed." Users have to jump to `kubectl` to figure out what's actually wrong.

**What I Changed**

Added a basic diagnostics panel that checks:
- Namespace exists (`gadget`)
- DaemonSet status (desired vs ready replicas)
- Pod health (crash loops, image pull errors, pending)
- Node coverage (are gadget pods on all schedulable nodes?)

Each check shows pass/warn/fail with details you can expand. Way more useful than a static error message.

**Why This Helps**

Instead of guessing, users can now see if IG is actually missing vs just misconfigured or failing to start.

**Testing**

Built locally, ran `tsc --noEmit` and `npm run lint`. All good.

<img width="1235" height="466" alt="image" src="https://github.com/user-attachments/assets/1f42d0db-4061-460b-95dc-18d88100f549" />
