### PR TITLE
fix: preserve field metadata to format duration columns in trace_dns

### DIFF
--- a/src/common/GadgetContext/index.tsx
+++ b/src/common/GadgetContext/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { createContext } from 'react';
 import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
+import { AllColumnMeta } from '../../gadgets/utility';
 
 // Create a context for sharing gadget-related state
 export const GadgetContext = createContext(null);
@@ -24,6 +25,7 @@ export function useGadgetState() {
   const [isRunningInBackground, setIsRunningInBackground] = useState(false);
   const [dynamicTabs, setDynamicTabs] = useState([]);
   const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const [columnMeta, setColumnMeta] = useState<AllColumnMeta>({});
 
   // Method to add a new dynamic tab
   const addDynamicTab = row => {
@@ -60,7 +62,9 @@ export function useGadgetState() {
   const prepareGadgetInfo = info => {
     setIsGadgetInfoFetched(true);
     const fields = {};
+    const meta: AllColumnMeta = {};
     info.dataSources.forEach((dataSource, index) => {
+      const dsID = dataSource.id || index;
       const annotations = dataSource.annotations;
       const isMetricAnnotationAvailable =
         annotations &&
@@ -68,6 +72,18 @@ export function useGadgetState() {
           annotationKey =>
             annotationKey === 'metrics.print' && annotations[annotationKey] === 'true'
         );
+
+      // Build per-field metadata map for this datasource
+      meta[dsID] = {};
+      dataSource.fields
+        .filter(field => (field.flags & 4) === 0)
+        .filter(field => field.fullName !== 'k8s')
+        .forEach(field => {
+          meta[dsID][field.fullName] = {
+            type: field.type,
+            annotations: field.annotations,
+          };
+        });
 
       if (isMetricAnnotationAvailable) {
         const fieldsFromDataSource = dataSource.fields
@@ -82,9 +98,9 @@ export function useGadgetState() {
         fieldsFromDataSource.push(`${HEADLAMP_VALUE}_${value?.fullName}`);
         fieldsFromDataSource.push(`${HEADLAMP_METRIC_UNIT}_${metricUnit}`);
         fieldsFromDataSource.push(IS_METRIC);
-        fields[dataSource.id || index] = fieldsFromDataSource;
+        fields[dsID] = fieldsFromDataSource;
       } else {
-        fields[dataSource.id || index] = dataSource.fields
+        fields[dsID] = dataSource.fields
           .filter(field => (field.flags & 4) === 0)
           .map(field => field.fullName)
           .filter(field => field !== 'k8s');
@@ -94,6 +110,7 @@ export function useGadgetState() {
     setGadgetConfig(info);
     setDataSources(info.dataSources);
     setDataColumns({ ...fields });
+    setColumnMeta(meta);
   };
 
   return {
@@ -134,5 +151,7 @@ export function useGadgetState() {
     setActiveTabIndex,
     addDynamicTab,
     removeDynamicTab,
+    columnMeta,
+    setColumnMeta,
   };
 }

--- a/src/common/GadgetWithDataSource/index.tsx
+++ b/src/common/GadgetWithDataSource/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import React, { useEffect, useMemo } from 'react';
 import GadgetFilters from '../../gadgets/gadgetFilters';
+import { AllColumnMeta } from '../../gadgets/utility';
 import { IS_METRIC } from '../helpers';
 import { MetricChart } from '../MetricChart';
 
@@ -40,6 +41,7 @@ interface GadgetWithDataSourceProps {
   headlessGadgetRunCallback: (success: any) => void;
   headlessGadgetDeleteCallback: (success: any) => void;
   handleRun: () => void;
+  columnMeta?: AllColumnMeta;
 }
 
 export function GadgetWithDataSource(props: GadgetWithDataSourceProps) {
@@ -65,6 +67,7 @@ export function GadgetWithDataSource(props: GadgetWithDataSourceProps) {
     headlessGadgetDeleteCallback = () => {},
     headlessGadgetRunCallback = () => {},
     handleRun = () => {},
+    columnMeta,
   } = props;
   const areAllPodStreamsConnected = podStreamsConnected === podsSelected.length;
 
@@ -79,12 +82,16 @@ export function GadgetWithDataSource(props: GadgetWithDataSourceProps) {
 
   const fields = useMemo(
     () =>
-      columns?.map(column => ({
-        header: column,
-        accessorFn: (data: any) =>
-          column === 'timestamp' ? <DateLabel date={data[column]} /> : data[column],
-      })),
-    [columns]
+      columns?.map(column => {
+        const meta = columnMeta?.[dataSourceID]?.[column];
+        const header = meta?.annotations?.['columns.title'] || column;
+        return {
+          header,
+          accessorFn: (data: any) =>
+            column === 'timestamp' ? <DateLabel date={data[column]} /> : data[column],
+        };
+      }),
+    [columns, columnMeta, dataSourceID]
   );
 
   useEffect(() => {

--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import usePortForward from '../../gadgets/igSocket';
-import { createGadgetCallbacks } from '../../gadgets/utility';
+import { AllColumnMeta, createGadgetCallbacks } from '../../gadgets/utility';
 
 interface GenericGadgetRendererProps {
   podsSelected: string[];
@@ -18,6 +18,7 @@ interface GenericGadgetRendererProps {
   prepareGadgetInfo: (info: any) => void;
   setPodStreamsConnected: React.Dispatch<React.SetStateAction<number>>;
   imageName: string;
+  columnMeta?: AllColumnMeta;
 }
 
 export default function GenericGadgetRenderer({
@@ -35,6 +36,7 @@ export default function GenericGadgetRenderer({
   prepareGadgetInfo,
   setPodStreamsConnected,
   imageName,
+  columnMeta,
 }: GenericGadgetRendererProps) {
   const { ig, isConnected } = usePortForward(
     `api/v1/namespaces/gadget/pods/${podSelected}/portforward?ports=8080`
@@ -55,7 +57,8 @@ export default function GenericGadgetRenderer({
       setLoading,
       setGadgetData,
       setBufferedGadgetData,
-      prepareGadgetInfo
+      prepareGadgetInfo,
+      columnMeta
     );
     if (gadgetInstance) {
       // Clear any pending attachment timeout

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -17,7 +17,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { processGadgetData } from './utility';
+import { AllColumnMeta, processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;
@@ -223,14 +223,21 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
   const dataColumnsRef = useRef(dataColumns); // Create a ref to store dataColumns
   const stopAttachmentRef = useRef(null); // Reference to store the stop function
   const [error, setError] = useState(null);
+  const [columnMeta, setColumnMeta] = useState<AllColumnMeta>({});
+  const columnMetaRef = useRef<AllColumnMeta>({});
   useEffect(() => {
     dataColumnsRef.current = dataColumns; // Update the ref whenever dataColumns changes
   }, [dataColumns]);
+  useEffect(() => {
+    columnMetaRef.current = columnMeta;
+  }, [columnMeta]);
 
   const prepareGadgetInfo = info => {
     setIsGadgetInfoFetched(true);
     const fields = {};
+    const meta: AllColumnMeta = {};
     info.dataSources.forEach((dataSource, index) => {
+      const dsID = dataSource.id || index;
       const annotations = dataSource.annotations;
       const isMetricAnnotationAvailable =
         annotations &&
@@ -238,6 +245,18 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
           annotationKey =>
             annotationKey === 'metrics.print' && annotations[annotationKey] === 'true'
         );
+
+      // Build per-field metadata map for this datasource
+      meta[dsID] = {};
+      dataSource.fields
+        .filter(field => (field.flags & 4) === 0)
+        .filter(field => field.fullName !== 'k8s')
+        .forEach(field => {
+          meta[dsID][field.fullName] = {
+            type: field.type,
+            annotations: field.annotations,
+          };
+        });
 
       if (isMetricAnnotationAvailable) {
         const fieldsFromDataSource = dataSource.fields
@@ -252,9 +271,9 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
         fieldsFromDataSource.push(`${HEADLAMP_VALUE}_${value?.fullName}`);
         fieldsFromDataSource.push(`${HEADLAMP_METRIC_UNIT}_${metricUnit}`);
         fieldsFromDataSource.push(IS_METRIC);
-        fields[dataSource.id || index] = fieldsFromDataSource;
+        fields[dsID] = fieldsFromDataSource;
       } else {
-        fields[dataSource.id || index] = dataSource.fields
+        fields[dsID] = dataSource.fields
           .filter(field => (field.flags & 4) === 0)
           .map(field => field.fullName)
           .filter(field => field !== 'k8s');
@@ -264,6 +283,8 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
     setGadgetConfig(info);
     setDataSources(info.dataSources);
     setDataColumns({ ...fields });
+    setColumnMeta(meta);
+    columnMetaRef.current = meta;
   };
 
   // Effect for gadget attachment/running
@@ -332,7 +353,8 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
                     dataColumnsRef.current[dsID] || [],
                     node,
                     setGadgetData,
-                    setBufferedGadgetData
+                    setBufferedGadgetData,
+                    columnMetaRef.current[dsID]
                   )
                 );
               },
@@ -378,7 +400,8 @@ const RunningGadgetForActiveTab = ({ instance, resource, ig }) => {
                     dataColumnsRef.current[dsID] || [],
                     node,
                     setGadgetData,
-                    setBufferedGadgetData
+                    setBufferedGadgetData,
+                    columnMetaRef.current[dsID]
                   )
                 );
               },

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -5,10 +5,28 @@ import { getProperty } from './helper';
 
 export const MAX_DATA_LIMIT = 20000;
 
+export type FieldMeta = { type?: string; annotations?: Record<string, string> };
+export type ColumnMeta = Record<string, FieldMeta>;
+export type AllColumnMeta = Record<string, ColumnMeta>;
+
+/**
+ * Format a nanosecond duration into a human-readable string.
+ */
+export function formatDuration(ns: number): string {
+  if (ns < 1_000) return `${ns}ns`;
+  if (ns < 1_000_000) return `${(ns / 1_000).toFixed(2)}µs`;
+  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)}ms`;
+  return `${(ns / 1_000_000_000).toFixed(2)}s`;
+}
+
 /**
  * Process a single column of gadget data
  */
-export const processDataColumn = (payload: any, column: string): React.ReactNode | null => {
+export const processDataColumn = (
+  payload: any,
+  column: string,
+  fieldMeta?: FieldMeta
+): React.ReactNode | null => {
   if (column === IS_METRIC || column.includes(HEADLAMP_KEY) || column.includes(HEADLAMP_VALUE)) {
     return null;
   }
@@ -33,8 +51,17 @@ export const processDataColumn = (payload: any, column: string): React.ReactNode
       ) : (
         value
       );
-    default:
-      return JSON.stringify(value).replace(/['"]+/g, '');
+    default: {
+      const raw = JSON.stringify(value).replace(/['"]+/g, '');
+      const isDuration =
+        fieldMeta?.type === 'gadget_duration_ns' ||
+        fieldMeta?.annotations?.['columns.formatter'] === 'duration';
+      if (isDuration) {
+        const ns = Number(value);
+        return isNaN(ns) ? raw : formatDuration(ns);
+      }
+      return raw;
+    }
   }
 };
 
@@ -47,14 +74,15 @@ export const processGadgetData = (
   columns: string[],
   node: string,
   setGadgetData: React.Dispatch<React.SetStateAction<Record<string, any>>>,
-  setBufferedGadgetData: React.Dispatch<React.SetStateAction<Record<string, any[]>>>
+  setBufferedGadgetData: React.Dispatch<React.SetStateAction<Record<string, any[]>>>,
+  columnMetaForDs?: ColumnMeta
 ) => {
   if (columns.length === 0) return;
 
   const massagedData: Record<string, any> = columns.includes(IS_METRIC)
     ? data
     : columns.reduce((acc, column) => {
-        const processedValue = processDataColumn(data, column);
+        const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
         if (processedValue !== null) {
           acc[column] = processedValue;
         }
@@ -89,7 +117,8 @@ export const createGadgetCallbacks = (
   setLoading: (loading: boolean) => void,
   setGadgetData: React.Dispatch<React.SetStateAction<Record<string, any>>>,
   setBufferedGadgetData: React.Dispatch<React.SetStateAction<Record<string, any[]>>>,
-  prepareGadgetInfo?: (info: any) => void
+  prepareGadgetInfo?: (info: any) => void,
+  columnMeta?: AllColumnMeta
 ) => {
   return {
     onGadgetInfo: prepareGadgetInfo || (() => {}),
@@ -106,7 +135,8 @@ export const createGadgetCallbacks = (
           dataColumns[dsID] || [],
           node,
           setGadgetData,
-          setBufferedGadgetData
+          setBufferedGadgetData,
+          columnMeta?.[dsID]
         )
       );
     },


### PR DESCRIPTION
## Summary

Was playing around with `trace_dns` and noticed `latency_ns` was showing raw integers like `1500423`. The gadget API returns field metadata but `prepareGadgetInfo` was dropping it, so `processDataColumn` had no type info and just called `JSON.stringify` on everything.

Fixed it by keeping the metadata and using it to format duration fields properly.

## What was happening

`getGadgetInfo` returns descriptors with `type` and `annotations`, but the existing code stripped it to just the name:

```ts
.map(field => field.fullName)
```

So every value fell through to `JSON.stringify`, hence the raw numbers.

## What I changed

Store the metadata in a `columnMeta` map and thread it through the pipeline. When a field has type `gadget_duration_ns` or a `duration` formatter annotation, format it:

```
1500423 → 1.50ms
87654   → 87.65µs
```

Column headers also pick up `columns.title` from annotations when available.

## Testing

Verified formatting logic in isolation + ran `npx tsc --noEmit`, no new TypeScript errors.

<img width="675" height="305" alt="image" src="https://github.com/user-attachments/assets/c58b5315-5115-4aea-9f78-8ee20d90215c" />