### PR TITLE
fix: use getServerURL() for ArtifactHub proxy fetch

### DIFF
--- a/src/api/artifacthub.tsx
+++ b/src/api/artifacthub.tsx
@@ -1,5 +1,7 @@
+import { getServerURL } from '../gadgets/helper';
+
 export function fetchInspektorGadgetFromArtifactHub() {
-  return fetch(`http://localhost:4466/externalproxy`, {
+  return fetch(`${getServerURL()}/externalproxy`, {
     headers: {
       'Forward-To': `https://artifacthub.io/api/v1/packages/search?kind=22&ts_query_web=inspektor+gadget&official=true&facets=true&limit=${60}&offset=0`,
     },


### PR DESCRIPTION
## Summary

- Replace `http://localhost:4466` with `getServerURL()` in the ArtifactHub fetch
- Import `getServerURL` from which already handles all environments

## Problem

The gadget gallery fetch packages from ArtifactHub by a local proxy endpoint. The URL was hardcoded to `http://localhost:4466`, which is only correct for headlamp desktop. So anyone running Headlamp through Docker desktop (which use port `64446`) would get no results in the gadget gallery.

The `getServerURL()` in `src/gadgets/helper.ts` is already there to resolve the correct base URL per environment but was not used in this file.