### PR TITLE
feat: add visual status indicators in background instances table

### DIFF
--- a/src/gadgets/backgroundgadgets.tsx
+++ b/src/gadgets/backgroundgadgets.tsx
@@ -150,7 +150,19 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
     {
       id: 'Status',
       header: 'Status',
-      accessorFn: row => (row.isHeadless ? 'Running In Background' : 'Not Running'),
+      accessorFn: row => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box
+            sx={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              backgroundColor: row.isHeadless ? '#4caf50' : '#9e9e9e',
+            }}
+          />
+          {row.isHeadless ? 'Running' : 'Stopped'}
+        </Box>
+      ),
     },
     {
       id: 'embedded',


### PR DESCRIPTION
## Summary
Improved the **Gadgets -> Running instances** table by adding small colored dots with the status text, so that operators can scan running vs stopped gadget instances at a glance.

## Motivation
Aligns with better observability from a user perspective.

## Screenshots
### Before
<img width="1625" height="554" alt="Screenshot 2026-03-22 230918" src="https://github.com/user-attachments/assets/803aae01-5a80-4489-b329-e084d9e41f98" />

### After
<img width="1639" height="537" alt="Screenshot 2026-03-22 230943" src="https://github.com/user-attachments/assets/eafbaf53-c6a0-4c6f-874c-559f81139697" />