### PR TITLE
fix: resolve TypeScript errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inspektor-gadget",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inspektor-gadget",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.3",
       "dependencies": {
         "pako": "^2.1.0",
         "react": "^18.3.1",
@@ -145,7 +145,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -545,7 +544,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -569,7 +567,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -658,7 +655,6 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -705,7 +701,6 @@
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1945,17 +1940,6 @@
         "headlamp-plugin": "bin/headlamp-plugin.js"
       }
     },
-    "node_modules/@kinvolk/headlamp-plugin/node_modules/@mui/core-downloads-tracker": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.17.1.tgz",
-      "integrity": "sha512-OcZj+cs6EfUD39IoPBOgN61zf1XFVY+imsGoBDwXeSq2UHJZE3N59zzBOVjclck91Ne3e9gudONOeILvHCIhUA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
     "node_modules/@kinvolk/headlamp-plugin/node_modules/@mui/icons-material": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.17.1.tgz",
@@ -1978,53 +1962,6 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@kinvolk/headlamp-plugin/node_modules/@mui/material": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
-      "integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.17.1",
-        "@mui/system": "^5.17.1",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }
@@ -2177,9 +2114,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.8.tgz",
-      "integrity": "sha512-vjP4+A1ybyCRhDZC7r5EPWu/gLseFZxaGyPdDl94vzVvk6Yj6gahdaqcjbhkaCrJjdZj90m3VioltWPAnWF/zw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2268,28 +2205,27 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.8.tgz",
-      "integrity": "sha512-5S9UTjKZZBd9GfbcYh/nYfD9cv6OXmj5Y7NgKYfk7JcSoshp8/pW5zP4wecRiroBSZX8wcrywSgogpVNO+5W0Q==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
+      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.4.8",
-        "@mui/system": "^6.4.8",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.8",
+        "@babel/runtime": "^7.23.9",
+        "@mui/core-downloads-tracker": "^5.18.0",
+        "@mui/system": "^5.18.0",
+        "@mui/types": "~7.2.15",
+        "@mui/utils": "^5.17.1",
         "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^19.0.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2298,7 +2234,6 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.4.8",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2310,144 +2245,6 @@
         "@emotion/styled": {
           "optional": true
         },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/@mui/private-theming": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.8.tgz",
-      "integrity": "sha512-sWwQoNSn6elsPTAtSqCf+w5aaGoh7AASURNmpy+QTTD/zwJ0Jgwt0ZaaP6mXq2IcgHxYnYloM/+vJgHPMkRKTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.8",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/@mui/styled-engine": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.8.tgz",
-      "integrity": "sha512-oyjx1b1FvUCI85ZMO4trrjNxGm90eLN3Ohy0AP/SqK5gWvRQg1677UjNf7t6iETOKAleHctJjuq0B3aXO2gtmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/@mui/system": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.8.tgz",
-      "integrity": "sha512-gV7iBHoqlsIenU2BP0wq14BefRoZcASZ/4LeyuQglayBl+DfLX5rEd3EYR3J409V2EZpR0NOM1LATAGlNk2cyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.8",
-        "@mui/styled-engine": "^6.4.8",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.8",
-        "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/@mui/utils": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.8.tgz",
-      "integrity": "sha512-C86gfiZ5BfZ51KqzqoHi1WuuM2QdSKoFhbkZeAfQRB+jCc4YNhhj11UXFVMMsqBgZ+Zy8IHNJW3M9Wj/LOwRXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "~7.2.24",
-        "@types/prop-types": "^15.7.14",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
@@ -2492,14 +2289,15 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.16.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.14.tgz",
-      "integrity": "sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
@@ -2525,16 +2323,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.17.1.tgz",
-      "integrity": "sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
+      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.16.14",
+        "@mui/styled-engine": "^5.18.0",
         "@mui/types": "~7.2.15",
         "@mui/utils": "^5.17.1",
         "clsx": "^2.1.0",
@@ -4096,7 +3893,6 @@
       "integrity": "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.69.0"
       },
@@ -4196,7 +3992,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4630,7 +4425,6 @@
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4642,7 +4436,6 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4782,7 +4575,6 @@
       "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.28.0",
@@ -4813,7 +4605,6 @@
       "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.28.0",
         "@typescript-eslint/types": "8.28.0",
@@ -5294,8 +5085,7 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@xyflow/react": {
       "version": "12.4.4",
@@ -5335,7 +5125,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5383,7 +5172,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6192,7 +5980,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -7065,8 +6852,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "2.12.1",
@@ -7162,7 +6948,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7700,7 +7485,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -7944,7 +7728,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8022,7 +7805,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8079,7 +7861,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8143,7 +7924,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8261,7 +8041,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8326,7 +8105,6 @@
       "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8360,7 +8138,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8439,7 +8216,6 @@
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -8450,7 +8226,6 @@
       "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -9803,7 +9578,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -10805,7 +10579,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -10847,7 +10620,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12334,8 +12106,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/moo-color": {
       "version": "1.0.3",
@@ -12361,7 +12132,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -12865,8 +12635,7 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
       "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -13333,7 +13102,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13651,7 +13419,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13696,7 +13463,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13827,7 +13593,6 @@
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14136,8 +13901,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14488,7 +14252,6 @@
       "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -15121,7 +14884,6 @@
       "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.15"
       },
@@ -16131,7 +15893,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16625,7 +16386,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -16799,7 +16559,6 @@
       "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.9",
         "@vitest/mocker": "3.0.9",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   },
   "overrides": {
     "typescript": "5.6.2",
-    "@mui/material": "5"
+    "@mui/material": "5.16.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "recharts": "^2.13.3"
   },
   "overrides": {
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "@mui/material": "5"
   }
 }

--- a/src/common/NodeSelection/index.tsx
+++ b/src/common/NodeSelection/index.tsx
@@ -1,5 +1,5 @@
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import {
   Box,
   Checkbox,
@@ -11,6 +11,7 @@ import {
   OutlinedInput,
   Select,
   Typography,
+  SelectChangeEvent,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { isIGPod } from '../../gadgets/helper';
@@ -60,8 +61,8 @@ interface NodeSelectionProps {
 }
 
 export function NodeSelection(props: NodeSelectionProps) {
-  const [nodes] = K8s.ResourceClasses.Node.useList() as [Node[]];
-  const [pods] = K8s.ResourceClasses.Pod.useList() as [Pod[]];
+  const [nodes] = K8s.ResourceClasses.Node.useList() as unknown as [Node[]];
+  const [pods] = K8s.ResourceClasses.Pod.useList() as unknown as [Pod[]];
   const [finalNodes, setFinalNodes] = useState<Node[]>(null);
   const {
     setPodsSelected,
@@ -157,11 +158,12 @@ export function NodeSelection(props: NodeSelectionProps) {
     return <Loader title="Loading" />;
   }
 
-  const handleChange = (event: { target: { value: string[] } }) => {
+  const handleChange = (event: SelectChangeEvent<string[]>) => {
     // Skip handling changes if selection is disabled
     if (selectionDisabled && !isInstantRun) return;
-
-    const { value } = event.target;
+    const value = Array.isArray(event.target.value)
+      ? event.target.value
+      : event.target.value.split(',');
     setNodesSelected(value);
 
     const podsInterestedIn = value.reduce<Pod[]>((acc, nodeName) => {
@@ -174,7 +176,7 @@ export function NodeSelection(props: NodeSelectionProps) {
 
   const ITEM_HEIGHT = 48;
   const ITEM_PADDING_TOP = 8;
-  const MenuProps: MUIMenuProps = {
+  const MenuProps: Partial<MUIMenuProps> = {
     PaperProps: {
       style: {
         maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,

--- a/src/common/gadgetbackgroundinstanceform.tsx
+++ b/src/common/gadgetbackgroundinstanceform.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@iconify/react';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import {
   Box,

--- a/src/gadgets/backgroundgadgets.tsx
+++ b/src/gadgets/backgroundgadgets.tsx
@@ -6,7 +6,7 @@ import {
   SectionBox,
   Table,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Button } from '@mui/material';
 import { Box, Tooltip } from '@mui/material';
@@ -90,7 +90,7 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
         updatedInstances = updatedInstances.filter(i => i.id !== id);
       } else {
         ig.deleteGadgetInstance(
-          id,
+          id as string,
           () => {},
           err => {
             console.error('Error deleting instance:', err);

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -1,5 +1,5 @@
 import { ConfirmDialog, Loader, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin'
 import { getCluster, getClusterPrefixedPath } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Typography } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';
@@ -18,7 +18,7 @@ export function GadgetDetails() {
   const gadgetState = useGadgetState();
 
   if (nodes === null || pods === null) {
-    return <Loader />;
+    return <Loader title="Loading" />;
   }
   const { imageName, id } = useParams<{ imageName: string; id: string }>();
   const embeddedInstances = JSON.parse(localStorage.getItem('headlamp_embeded_resources') || '[]');
@@ -78,6 +78,7 @@ function GadgetRenderer({
     gadgetConn,
     setPodsSelected,
     nodesSelected,
+    open,
     setOpen,
     setNodesSelected,
     setGadgetConn,

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -1,5 +1,5 @@
 import { ConfirmDialog, Loader, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
-import { K8s } from '@kinvolk/headlamp-plugin'
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { getCluster, getClusterPrefixedPath } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Typography } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';

--- a/src/gadgets/gadgetGrid.tsx
+++ b/src/gadgets/gadgetGrid.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@iconify/react';
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { getCluster, getClusterPrefixedPath } from '@kinvolk/headlamp-plugin/lib/Utils';
 import {
   Box,
@@ -165,7 +165,7 @@ export function GadgetCardEmbedWrapper({ gadget, embedDialogOpen, onClose, resou
               height: '100%',
             }}
           >
-            <Loader />
+            <Loader title="Loading" />
           </Box>
         </Box>
       </>
@@ -227,14 +227,13 @@ export function GadgetCardEmbedWrapper({ gadget, embedDialogOpen, onClose, resou
         <Box sx={{ overflow: 'auto', flexGrow: 1 }}>
           {gadgetInfo ? (
             <GadgetCreationStepper
-              ig={ig}
               imageName={gadget?.display_name.split(' ').join('_')}
               enableEmbed
               gadgetInfo={gadgetInfo}
               resource={resource}
             />
           ) : (
-            <Loader />
+            <Loader title="Loading" />
           )}
         </Box>
       </Box>
@@ -590,7 +589,6 @@ function Gadget({ gadget, nodes, pods, resource }) {
       <CreateGadgetInstance
         gadgetInfo={gadgetInfo}
         resource={resource}
-        ig={ig}
         imageName={imageName}
       />
     )

--- a/src/gadgets/list.tsx
+++ b/src/gadgets/list.tsx
@@ -1,5 +1,5 @@
 import { Loader } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { Box } from '@mui/material';
 import { IGNotFound } from '../common/NotFound';
 import Gadget from '.';
@@ -10,10 +10,10 @@ export default function GadgetList() {
   const isIGInstallationFound = isIGInstalled(pods);
 
   if (pods === null) {
-    return <Loader />;
+    return <Loader title="Loading" />;
   }
   if (isIGInstallationFound === null) {
-    return <Loader />;
+    return <Loader title="Loading" />;
   }
 
   if (!isIGInstallationFound) {

--- a/src/gadgets/params/filter.tsx
+++ b/src/gadgets/params/filter.tsx
@@ -33,7 +33,7 @@ const FilterComponent = ({ param, config, gadgetConfig }) => {
     console.log('Gadget info:', gadgetInfo);
     if (!gadgetInfo) return [];
     const tmpFields = [];
-    Object.values(gadgetInfo).forEach(ds => {
+    Object.values(gadgetInfo as Record<string, { name: string; fields: { fullName: string; name: string }[] }>).forEach(ds => {
       ds.fields.forEach(f => {
         tmpFields.push({ ds: ds.name, ...f });
       });

--- a/src/gadgets/params/sortingfilter.tsx
+++ b/src/gadgets/params/sortingfilter.tsx
@@ -16,7 +16,7 @@ const SortingFilter = ({ param, config, gadgetConfig }) => {
     if (!gadgetInfo) return [];
 
     const tmpFields = [];
-    Object.values(gadgetInfo).forEach(ds => {
+    Object.values(gadgetInfo as Record<string, { name: string; fields: { fullName: string; name: string }[] }>).forEach(ds => {
       ds.fields.forEach(f => {
         tmpFields.push({ ds: ds.name, field: f.fullName, display: `${ds.name}.${f.fullName}` });
       });
@@ -25,7 +25,7 @@ const SortingFilter = ({ param, config, gadgetConfig }) => {
   }, []);
 
   useEffect(() => {
-    const dataSources = {};
+    const dataSources: Record<string, any[]> = {};
     filters.forEach(f => {
       dataSources[f.field.ds] = [...(dataSources[f.field.ds] || []), f];
     });

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@iconify/react';
 import { ConfirmDialog, DateLabel, Table } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import {
   Accordion,
@@ -123,14 +123,14 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const groupedInstances = useMemo(() => {
     if (!gadgetInstances) return {};
 
-    return gadgetInstances.reduce((acc, instance) => {
+    return gadgetInstances.reduce((acc: Record<string, any[]>, instance) => {
       const imageName = instance.gadgetConfig.imageName;
       if (!acc[imageName]) {
         acc[imageName] = [];
       }
       acc[imageName].push(instance);
       return acc;
-    }, {});
+    }, {} as Record<string, any[]>);
   }, [gadgetInstances]);
 
   if (!gadgetInstances || gadgetInstances.length === 0) return null;
@@ -148,7 +148,7 @@ const RunningGadgetsForResource = ({ resource, open }) => {
       />
 
       {/* Grouped Instances */}
-      {Object.entries(groupedInstances).map(([imageName, instances]) => (
+      {(Object.entries(groupedInstances) as [string, any[]][]).map(([imageName, instances]) => (
         <Box key={imageName} sx={{ mb: 2 }}>
           <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
             {imageName} ({instances.length})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import {
   SectionBox,
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { DetailsViewSectionProps } from '@kinvolk/headlamp-plugin/lib/components/DetailsViewSection/DetailsViewSection';
-import K8s from '@kinvolk/headlamp-plugin/lib/K8s';
+import { K8s } from '@kinvolk/headlamp-plugin';
 import { Box, Typography } from '@mui/material';
 import { useState } from 'react';
 import { IGNotFound } from './common/NotFound';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "./node_modules/@kinvolk/headlamp-plugin/config/plugins-tsconfig.json",
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "paths": {
+      "@kinvolk/headlamp-plugin": ["./node_modules/@kinvolk/headlamp-plugin/lib/index.d.ts"]
+    }
+  }
 }


### PR DESCRIPTION
# Fix TypeScript compilation errors in `npm run tsc`

This PR fixes 24 TypeScript errors across 10 files that caused `npm run tsc` to fail completely. The changes are minimal and targeted, no runtime behavior is changed. The fixes address the following root causes:

- **Broken types entry point**: `@kinvolk/headlamp-plugin@0.11.4` incorrectly points `"types"` to `additional.d.ts` instead of `index.d.ts`. Fixed via `tsconfig.json` `paths` override as a workaround until corrected upstream.
- **MUI version conflict**: Transitive dependencies pull in `@mui/material@6.x`, conflicting with the v5 Grid API used in the codebase. Fixed by pinning v5 via `overrides`.
- **Stale `K8s` import path**: Switched to the correct named import from the package root instead of the non-existent `lib/K8s` subpath.
- **Minor type gaps**: Missing context destructuring, unnarrowed `unknown` variables, missing required props, and unused prop declarations.

## How to use

1. Check out this branch
2. Run `npm install`
3. Run `npm run tsc` and verify it exits cleanly with no errors

## Testing done
```zsh
❯ npm run tsc

> inspektor-gadget@0.1.0-beta.3 tsc
> headlamp-plugin tsc

".": tsc-ing, :node_modules/.bin/tsc --noEmit:...
Done tsc-ing: ".".
```

Verified that `npm run tsc` goes from 24 errors across 10 files (on `main`) to zero errors on this branch.

## Checklist
+ [x] This PR fixes #70
+ [x] Commits are signed-off
+ [x] `npm run tsc` passes locally