### PR TITLE
fix: avoid redundant gadget name save operation

### DIFF
--- a/src/common/GadgetDescription/index.tsx
+++ b/src/common/GadgetDescription/index.tsx
@@ -183,7 +183,6 @@ export function GadgetDescription({
                     control={
                       <Select
                         labelId="embed-type-label"
-                        // size='small'
                         value={embedView}
                         size="small"
                         label="Embed Type"

--- a/src/common/GadgetDescription/index.tsx
+++ b/src/common/GadgetDescription/index.tsx
@@ -60,6 +60,10 @@ export function GadgetDescription({
 
   const saveEditedName = () => {
     if (!id || !editedName.trim()) return;
+    if (editedName.trim() === gadgetInstance?.name) {
+      setIsEditingName(false);
+      return;
+    }
 
     const allInstances = JSON.parse(localStorage.getItem('headlamp_embeded_resources') || '[]');
 
@@ -84,6 +88,8 @@ export function GadgetDescription({
       </Box>
     );
   }
+
+  console.log('enableHistoricalData', enableHistoricalData);
 
   return (
     <Card elevation={2} sx={{ mx: 'auto', mt: 2, mb: 2 }}>
@@ -177,6 +183,7 @@ export function GadgetDescription({
                     control={
                       <Select
                         labelId="embed-type-label"
+                        // size='small'
                         value={embedView}
                         size="small"
                         label="Embed Type"


### PR DESCRIPTION
# Avoid unnecessary localstorage update when saving unchanged gadget name

Avoid unnecessary local storage updates by checking if the edited gadget
name differs from the existing name before saving.

fixes #74 

## How to use

Try saving the unchanged gadget name

## Videos

[Screencast from 2026-03-23 02-49-51.webm](https://github.com/user-attachments/assets/f8bf46de-ea93-47bc-91c1-2ec96ab85ab8)
