### PR TITLE
feat: improve embed dropdown size for better description panel consistency

### DIFF
--- a/src/common/GadgetDescription/index.tsx
+++ b/src/common/GadgetDescription/index.tsx
@@ -179,6 +179,7 @@ export function GadgetDescription({
                       <Select
                         labelId="embed-type-label"
                         value={embedView}
+                        size="small"
                         label="Embed Type"
                         onChange={e => {
                           setEmbedView(e.target.value);


### PR DESCRIPTION
# Improve Embed dropdown size for better UI consistency in gadget configuration panel

Improve the embed dropdown size in the gadget description panel for better UI consistency.

fixes #78 


<img width="1624" height="271" alt="Screenshot from 2026-03-23 13-20-52" src="https://github.com/user-attachments/assets/e82fef9b-8eea-456c-a527-26652abca8c2" />
