### PR TITLE
fix: resolve gadget version dynamically

### DIFF
--- a/src/api/artifacthub.tsx
+++ b/src/api/artifacthub.tsx
@@ -1,4 +1,5 @@
 import { getServerURL } from '../gadgets/helper';
+import { normalizeName } from '../gadgets/helper';
 
 export function fetchInspektorGadgetFromArtifactHub() {
   return fetch(`${getServerURL()}/externalproxy`, {
@@ -10,4 +11,30 @@ export function fetchInspektorGadgetFromArtifactHub() {
     .then(data => {
       return data.packages;
     });
+}
+
+export async function fetchGadgetVersionFromArtifactHub(imageURL: string) {
+  const gadgetName = imageURL.split('/').pop()?.split(':')[0];
+  const normalizedImageName = normalizeName(gadgetName);
+
+  const response = await fetch(`${getServerURL()}/externalproxy`, {
+    headers: {
+      'Forward-To': `https://artifacthub.io/api/v1/packages/search?ts_query_web=${gadgetName}`,
+    },
+  });
+
+  const data = await response.json();
+
+  const gadget = data.packages.find(
+    g =>
+      normalizeName(g.normalized_name) === normalizedImageName ||
+      normalizeName(g.name) === normalizedImageName
+  );
+
+  if (!gadget) {
+    console.log('Gadget not found for', gadgetName);
+    return '1';
+  }
+
+  return gadget.version;
 }

--- a/src/gadgets/gadgetGrid.tsx
+++ b/src/gadgets/gadgetGrid.tsx
@@ -304,7 +304,7 @@ const GadgetCard = ({ gadget, onEmbedClick, resource = null }) => {
                           generateRandomString(),
                         gadgetConfig: {
                           imageName: gadget.display_name?.split(' ').join('_'),
-                          version: 1,
+                          version: gadget.version,
                           paramValues: {},
                         },
                         description: gadget.description,
@@ -503,11 +503,7 @@ function CreateGadgetInstance({ gadgetInfo, resource, imageName, enableEmbed = f
   );
 }
 
-const GadgetGrid = ({
-  gadgets,
-  onEmbedClick,
-  resource = null,
-}) => {
+const GadgetGrid = ({ gadgets, onEmbedClick, resource = null }) => {
   if (gadgets.length === 0) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100%">

--- a/src/gadgets/gadgetInput.tsx
+++ b/src/gadgets/gadgetInput.tsx
@@ -2,9 +2,12 @@ import { Icon } from '@iconify/react';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Button, TextField } from '@mui/material';
 import { useSnackbar } from 'notistack';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { generateRandomString } from '../common/helpers';
+import { fetchGadgetVersionFromArtifactHub } from '../api/artifacthub';
+import { isLatestTag } from './helper';
+import { extractVersionFromImage } from './helper';
 
 export function GadgetInput({ resource, onAddGadget }) {
   const [imageURL, setImageURL] = useState('');
@@ -12,13 +15,21 @@ export function GadgetInput({ resource, onAddGadget }) {
   const { enqueueSnackbar } = useSnackbar();
   const encodedImageURL = encodeURIComponent(imageURL);
 
-  const handleRun = () => {
+  const handleRun = async () => {
+    let version: string;
+
+    if (isLatestTag(imageURL)) {
+      version = await fetchGadgetVersionFromArtifactHub(imageURL);
+    } else {
+      version = extractVersionFromImage(imageURL);
+    }
+
     const row: {
       id: string;
       isHeadless: boolean;
       gadgetConfig: {
         imageName: string;
-        version: number;
+        version: string;
         paramValues: object;
       };
       name: string;
@@ -30,7 +41,7 @@ export function GadgetInput({ resource, onAddGadget }) {
       isHeadless: undefined,
       gadgetConfig: {
         imageName: encodedImageURL,
-        version: 1,
+        version: version,
         paramValues: {},
       },
       name: 'gadget-custom-' + generateRandomString(),
@@ -59,10 +70,9 @@ export function GadgetInput({ resource, onAddGadget }) {
 
   return (
     <Box mt={2} display="flex" alignItems="center">
-        
       <TextField
         label="Gadget Image URL"
-        placeholder='ghcr.io/inspektor-gadget/gadget/trace_open:latest'
+        placeholder="ghcr.io/inspektor-gadget/gadget/trace_open:latest"
         variant="outlined"
         size="small"
         fullWidth

--- a/src/gadgets/helper.ts
+++ b/src/gadgets/helper.ts
@@ -25,6 +25,21 @@ export function getProperty(obj, key) {
   return keys.reduce((acc, curr) => acc && acc[curr], obj);
 }
 
+export const isLatestTag = (imageURL: string) => {
+  const imageTag = imageURL.split(':')[1];
+
+  return imageTag === 'latest';
+};
+
+export function extractVersionFromImage(imageURL: string): string {
+  const tag = imageURL.split(':')[1];
+
+  if (!tag || tag === 'latest') return '1';
+
+  const versionMatch = tag.match(/v?(\d+\.\d+\.\d+)/);
+
+  return versionMatch ? versionMatch[1] : '1';
+}
 export const createIdentifier = (identifier, value) =>
   `headlamp_${JSON.stringify({ [identifier]: value })}`;
 
@@ -78,4 +93,8 @@ export function getServerURL() {
     return 'http://localhost:64446';
   }
   return 'http://localhost:4466';
+}
+
+export function normalizeName(name: string) {
+  return name.toLowerCase().replace(/[_\s]/g, '-').trim();
 }


### PR DESCRIPTION
# fix: resolve gadget version dynamically instead of hardcoding to 1

The gadget version was hardcoded to 1 causing incorrect version information to be stored and displayed in the gadgets list.

fixes #83 


[Screencast from 2026-03-26 00-29-18.webm](https://github.com/user-attachments/assets/c3331c53-f6e0-4b33-b91a-bf32fac266fa)
