### PR TITLE
 fix: duplicate localStorage entries when stopping a background gadget

### DIFF
--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -229,13 +229,13 @@ function GadgetRenderer({
       () => {
         const newID = imageName + '-custom-' + generateRandomString();
 
-        updateInstanceFromStorage(id, 'None', false);
         const allInstances = JSON.parse(localStorage.getItem('headlamp_embeded_resources') || '[]');
         const instance = allInstances.find(instance => instance.id === id);
+        const filteredInstances = allInstances.filter(instance => instance.id !== id);
         localStorage.setItem(
           'headlamp_embeded_resources',
           JSON.stringify([
-            ...allInstances,
+            ...filteredInstances,
             {
               id: newID,
               name: instance.name,


### PR DESCRIPTION
this pr fixes a bug in `deleteHeadlessGadget` where stopping a background gadget would create a duplicate entry in `localStorage`.
previously, the function called `updateInstanceFromStorage`, which re-added the old instance, and then appended a new instance on top of it. over time, this caused duplicate entries to accumulate.
the fix removes the `updateInstanceFromStorage` call and instead filters out the old instance before adding the new one. this ensures only the correct instance is stored and prevents ghost gadgets from appearing.

fixes: #87 
