### PR TITLE
Fix: Don't silently swallow delete errors for gadget instances

### DIFF
--- a/src/common/GadgetContext/index.tsx
+++ b/src/common/GadgetContext/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { createContext } from 'react';
-import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 import { AllColumnMeta, getSortedColumns } from '../../gadgets/utility';
+import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 
 // Create a context for sharing gadget-related state
 export const GadgetContext = createContext(null);

--- a/src/gadgets/backgroundgadgets.tsx
+++ b/src/gadgets/backgroundgadgets.tsx
@@ -78,9 +78,6 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
     const capturedTable = tableInstance;
     const selectedRows = capturedTable.getSelectedRowModel().rows;
     const selectedIds = new Set(selectedRows.map(r => r.original.id)) as Set<string>;
-    const localStorageInstances: any[] = JSON.parse(
-      localStorage.getItem('headlamp_embeded_resources') || '[]'
-    );
 
     // Separate instances that need an API call (headless) from those that don't
     const toDeleteLocally = new Set<string>();
@@ -89,10 +86,10 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
     selectedIds.forEach(id => {
       const instance = (runningInstances || []).find(i => i.id === id);
       if (!instance) return;
-      if (instance.isHeadless !== undefined && !instance.isHeadless) {
-        toDeleteLocally.add(id);
-      } else {
+      if (instance.isHeadless) {
         toDeleteRemotely.push({ id, name: instance.name || id.slice(-8) });
+      } else {
+        toDeleteLocally.add(id);
       }
     });
 
@@ -103,7 +100,15 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
 
     const finalizeDelete = () => {
       const allDeletedIds = new Set([...toDeleteLocally, ...remoteDeletedIds]);
-      const updatedStorage = localStorageInstances.filter(i => !allDeletedIds.has(i.id));
+      let latestLocalStorageInstances: any[] = [];
+      try {
+        const stored = localStorage.getItem('headlamp_embeded_resources');
+        const parsed = stored ? JSON.parse(stored) : [];
+        latestLocalStorageInstances = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        latestLocalStorageInstances = [];
+      }
+      const updatedStorage = latestLocalStorageInstances.filter(i => !allDeletedIds.has(i.id));
       localStorage.setItem('headlamp_embeded_resources', JSON.stringify(updatedStorage));
       setRunningInstances(prev => (prev || []).filter(i => !allDeletedIds.has(i.id)));
       capturedTable.resetRowSelection();
@@ -117,8 +122,13 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
     }
 
     if (!ig) {
-      enqueueSnackbar('Not connected to gadget API. Please try again.', { variant: 'error' });
-      setOpenConfirmDialog(false);
+      enqueueSnackbar(
+        toDeleteLocally.size > 0
+          ? 'Not connected to gadget API. Local instances were deleted, but remote instances could not be deleted.'
+          : 'Not connected to gadget API. Remote instances could not be deleted. Please try again.',
+        { variant: 'error' }
+      );
+      finalizeDelete();
       return;
     }
 

--- a/src/gadgets/backgroundgadgets.tsx
+++ b/src/gadgets/backgroundgadgets.tsx
@@ -10,6 +10,7 @@ import K8s from '@kinvolk/headlamp-plugin/lib/k8s';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Button } from '@mui/material';
 import { Box, Tooltip } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { IGNotFound } from '../common/NotFound';
 import { isIGInstalled, useGadgetConn } from './conn';
@@ -17,13 +18,14 @@ import { isIGInstalled, useGadgetConn } from './conn';
 export function BackgroundRunning({ embedDialogOpen = false }) {
   const [nodes] = K8s.ResourceClasses.Node.useList();
   const [pods] = K8s.ResourceClasses.Pod.useList();
-  const [runningInstances, setRunningInstances] = React.useState(null);
+  const [runningInstances, setRunningInstances] = React.useState<any[] | null>(null);
   const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
-  const [tableInstance, setTableInstance] = useState(null);
+  const [tableInstance, setTableInstance] = useState<any>(null);
   const isIGInstallationFound = isIGInstalled(pods);
   const [selectedCount, setSelectedCount] = useState(0);
   const ig = useGadgetConn(nodes, pods);
   const cluster = getCluster();
+  const { enqueueSnackbar } = useSnackbar();
 
   useEffect(() => {
     if (!ig) return;
@@ -73,39 +75,70 @@ export function BackgroundRunning({ embedDialogOpen = false }) {
   const handleDeleteInstances = () => {
     if (!tableInstance) return;
 
-    const selectedRows = tableInstance.getSelectedRowModel().rows;
+    const capturedTable = tableInstance;
+    const selectedRows = capturedTable.getSelectedRowModel().rows;
     const selectedIds = new Set(selectedRows.map(r => r.original.id)) as Set<string>;
-    const localStorageInstances = JSON.parse(
+    const localStorageInstances: any[] = JSON.parse(
       localStorage.getItem('headlamp_embeded_resources') || '[]'
     );
 
-    let updatedInstances = [...localStorageInstances];
-    let updatedDisplayInstances = [...(runningInstances || [])];
+    // Separate instances that need an API call (headless) from those that don't
+    const toDeleteLocally = new Set<string>();
+    const toDeleteRemotely: { id: string; name: string }[] = [];
 
     selectedIds.forEach(id => {
-      const instance = runningInstances.find(instance => instance.id === id);
+      const instance = (runningInstances || []).find(i => i.id === id);
       if (!instance) return;
-
       if (instance.isHeadless !== undefined && !instance.isHeadless) {
-        updatedInstances = updatedInstances.filter(i => i.id !== id);
+        toDeleteLocally.add(id);
       } else {
-        ig.deleteGadgetInstance(
-          id,
-          () => {},
-          err => {
-            console.error('Error deleting instance:', err);
-          }
-        );
-        updatedInstances = updatedInstances.filter(i => i.id !== id);
+        toDeleteRemotely.push({ id, name: instance.name || id.slice(-8) });
       }
-
-      updatedDisplayInstances = updatedDisplayInstances.filter(i => i.id !== id);
     });
 
-    localStorage.setItem('headlamp_embeded_resources', JSON.stringify(updatedInstances));
-    setRunningInstances(updatedDisplayInstances);
-    tableInstance.resetRowSelection(); // Reset row selection after updating data
-    setOpenConfirmDialog(false);
+    // Commit removals and close dialog once all async calls have settled
+    const remoteDeletedIds = new Set<string>();
+    let settledCount = 0;
+    const totalRemote = toDeleteRemotely.length;
+
+    const finalizeDelete = () => {
+      const allDeletedIds = new Set([...toDeleteLocally, ...remoteDeletedIds]);
+      const updatedStorage = localStorageInstances.filter(i => !allDeletedIds.has(i.id));
+      localStorage.setItem('headlamp_embeded_resources', JSON.stringify(updatedStorage));
+      setRunningInstances(prev => (prev || []).filter(i => !allDeletedIds.has(i.id)));
+      capturedTable.resetRowSelection();
+      setOpenConfirmDialog(false);
+    };
+
+    // No remote calls needed — finalize immediately
+    if (totalRemote === 0) {
+      finalizeDelete();
+      return;
+    }
+
+    if (!ig) {
+      enqueueSnackbar('Not connected to gadget API. Please try again.', { variant: 'error' });
+      setOpenConfirmDialog(false);
+      return;
+    }
+
+    toDeleteRemotely.forEach(({ id, name }) => {
+      ig.deleteGadgetInstance(
+        id,
+        () => {
+          remoteDeletedIds.add(id);
+          settledCount++;
+          if (settledCount === totalRemote) finalizeDelete();
+        },
+        (err: Error) => {
+          enqueueSnackbar(`Failed to delete "${name}": ${err?.message ?? String(err)}`, {
+            variant: 'error',
+          });
+          settledCount++;
+          if (settledCount === totalRemote) finalizeDelete();
+        }
+      );
+    });
   };
 
   if (pods === null) {

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -18,7 +18,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { AllColumnMeta, processGadgetData, getSortedColumns } from './utility';
+import { AllColumnMeta, getSortedColumns,processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -71,10 +71,6 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const confirmDeleteInstance = () => {
     if (!instanceToDelete) return;
 
-    const localStorageInstances: any[] = JSON.parse(
-      localStorage.getItem('headlamp_embeded_resources') || '[]'
-    );
-
     const instance = (gadgetInstances || []).find(i => i.id === instanceToDelete);
     if (!instance) {
       setInstanceToDelete(null);
@@ -83,7 +79,15 @@ const RunningGadgetsForResource = ({ resource, open }) => {
     }
 
     const removeFromStorage = (id: string) => {
-      const updated = localStorageInstances.filter(i => i.id !== id);
+      let current: any[] = [];
+      try {
+        const stored = localStorage.getItem('headlamp_embeded_resources');
+        const parsed = stored ? JSON.parse(stored) : [];
+        current = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        current = [];
+      }
+      const updated = current.filter(i => i.id !== id);
       localStorage.setItem('headlamp_embeded_resources', JSON.stringify(updated));
       setGadgetInstances(prev => (prev || []).filter(i => i.id !== id));
       setInstanceToDelete(null);

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -12,6 +12,7 @@ import {
   Paper,
   Typography,
 } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../common/helpers';
 import { MetricChart } from '../common/MetricChart';
@@ -26,9 +27,10 @@ function getGadgetPodForThisResourceNode(node, pods) {
 
 const RunningGadgetsForResource = ({ resource, open }) => {
   const [pods] = K8s.ResourceClasses.Pod.useList();
-  const [gadgetInstances, setGadgetInstances] = useState(null);
+  const [gadgetInstances, setGadgetInstances] = useState<any[] | null>(null);
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
-  const [instanceToDelete, setInstanceToDelete] = useState(null);
+  const [instanceToDelete, setInstanceToDelete] = useState<string | null>(null);
+  const { enqueueSnackbar } = useSnackbar();
 
   const node =
     resource?.jsonData.kind === 'Node'
@@ -69,54 +71,49 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const confirmDeleteInstance = () => {
     if (!instanceToDelete) return;
 
-    // Get a copy of the current localStorage
-    const localStorageInstances = JSON.parse(
+    const localStorageInstances: any[] = JSON.parse(
       localStorage.getItem('headlamp_embeded_resources') || '[]'
     );
 
-    // Find the instance to delete in the current state
-    const instance = gadgetInstances.find(instance => instance.id === instanceToDelete);
+    const instance = (gadgetInstances || []).find(i => i.id === instanceToDelete);
     if (!instance) {
-      console.error('Instance to delete not found in state.');
       setInstanceToDelete(null);
       setOpenConfirmDialog(false);
       return;
     }
 
-    let updatedLocalStorageInstances = [...localStorageInstances];
+    const removeFromStorage = (id: string) => {
+      const updated = localStorageInstances.filter(i => i.id !== id);
+      localStorage.setItem('headlamp_embeded_resources', JSON.stringify(updated));
+      setGadgetInstances(prev => (prev || []).filter(i => i.id !== id));
+      setInstanceToDelete(null);
+      setOpenConfirmDialog(false);
+    };
 
     if (instance.isHeadless) {
-      // Handle remote instance deletion
+      if (!ig) {
+        enqueueSnackbar('Not connected to gadget API. Please try again.', { variant: 'error' });
+        setInstanceToDelete(null);
+        setOpenConfirmDialog(false);
+        return;
+      }
       ig.deleteGadgetInstance(
         instanceToDelete,
         () => {
-          console.log('Remote instance deleted:', instanceToDelete);
+          removeFromStorage(instanceToDelete);
         },
-        err => {
-          console.error('Error deleting remote instance:', err);
+        (err: Error) => {
+          enqueueSnackbar(
+            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${err?.message ?? String(err)}`,
+            { variant: 'error' }
+          );
+          setInstanceToDelete(null);
+          setOpenConfirmDialog(false);
         }
       );
+    } else {
+      removeFromStorage(instanceToDelete);
     }
-
-    console.log('Deleting instance:', instanceToDelete);
-
-    // Remove the instance from localStorage
-    updatedLocalStorageInstances = updatedLocalStorageInstances.filter(
-      i => i.id !== instanceToDelete
-    );
-
-    // Update localStorage and state
-    localStorage.setItem(
-      'headlamp_embeded_resources',
-      JSON.stringify(updatedLocalStorageInstances)
-    );
-
-    setGadgetInstances(prevInstances =>
-      prevInstances.filter(instance => instance.id !== instanceToDelete)
-    );
-
-    setInstanceToDelete(null);
-    setOpenConfirmDialog(false);
   };
 
   // Group instances by image name

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -18,7 +18,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { AllColumnMeta, getSortedColumns,processGadgetData } from './utility';
+import { AllColumnMeta, getSortedColumns, processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;
@@ -104,7 +104,9 @@ const RunningGadgetsForResource = ({ resource, open }) => {
         },
         (err: Error) => {
           enqueueSnackbar(
-            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${err?.message ?? String(err)}`,
+            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${
+              err?.message ?? String(err)
+            }`,
             { variant: 'error' }
           );
           setInstanceToDelete(null);

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -9,7 +9,10 @@ export type FieldMeta = { type?: string; annotations?: Record<string, string> };
 export type ColumnMeta = Record<string, FieldMeta>;
 export type AllColumnMeta = Record<string, ColumnMeta>;
 
-export function getSortedColumns(columns: string[], annotations?: Record<string, string>): string[] {
+export function getSortedColumns(
+  columns: string[],
+  annotations?: Record<string, string>
+): string[] {
   const preferredOrderStr = annotations?.['columns'];
   if (preferredOrderStr) {
     const preferredOrder = preferredOrderStr.split(',').map(s => s.trim());
@@ -114,12 +117,12 @@ export const processGadgetData = (
   const massagedData: Record<string, any> = columns.includes(IS_METRIC)
     ? data
     : columns.reduce((acc, column) => {
-      const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
-      if (processedValue !== null) {
-        acc[column] = processedValue;
-      }
-      return acc;
-    }, {});
+        const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
+        if (processedValue !== null) {
+          acc[column] = processedValue;
+        }
+        return acc;
+      }, {});
 
   if (columns.includes(IS_METRIC)) {
     setBufferedGadgetData(prevData => ({
@@ -153,7 +156,7 @@ export const createGadgetCallbacks = (
   columnMeta?: AllColumnMeta
 ) => {
   return {
-    onGadgetInfo: prepareGadgetInfo || (() => { }),
+    onGadgetInfo: prepareGadgetInfo || (() => {}),
     onReady: () => setLoading(false),
     onDone: () => setLoading(false),
     onError: (error: any) => console.error('Gadget error:', error),


### PR DESCRIPTION
While looking into how instance deletion works, I noticed that when you delete a headless gadget instance, the UI immediately removes it from the table and updates localStorage, even if the actual delete request to the server failed.
I found that the success handler did nothing, and errors were only being logged to the browser console, which is completely invisible to the user.
What I realized could go wrong: If your connection dropped mid-delete, the gadget would still be running on the cluster, but disappear from the UI with no way to retry or even know something went wrong.

**What I changed:**

Moved the localStorage write and state update into the success callback where they belong, and wired up `enqueueSnackbar` on failure (same pattern already used in `gadgetbackgroundinstanceform.tsx`). Same fix applied to both `backgroundgadgets.tsx` and `resourcegadgets.tsx`.

**Before:** Delete a row → row disappears → gadget silently keeps running on cluster.

https://github.com/user-attachments/assets/925c4eeb-44cb-4e7f-a5b0-3cdb38671584


**After:** If the API call fails, the row stays put and a red snackbar shows `"Failed to delete instance <id>: <error>"` so you can actually retry.


https://github.com/user-attachments/assets/3dc76b93-59ec-41b7-9b1c-218ff7eb7255

<img width="1600" height="850" alt="image" src="https://github.com/user-attachments/assets/e7ff7afc-65d2-4bd7-92e4-f7f85c32fe46" />


Also handled the mixed headless/non-headless batch case , non-headless instances are removed immediately as before, headless ones only get removed after the API confirms success.