### PR TITLE
feat: surface mid-stream gadget errors to the user

### DIFF
--- a/src/common/GadgetContext/index.tsx
+++ b/src/common/GadgetContext/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { createContext } from 'react';
-import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 import { AllColumnMeta, getSortedColumns } from '../../gadgets/utility';
+import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../helpers';
 
 // Create a context for sharing gadget-related state
 export const GadgetContext = createContext(null);

--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -19,6 +19,7 @@ interface GenericGadgetRendererProps {
   setPodStreamsConnected: React.Dispatch<React.SetStateAction<number>>;
   imageName: string;
   columnMeta?: AllColumnMeta;
+  setStreamError?: (msg: string) => void;
 }
 
 export default function GenericGadgetRenderer({
@@ -37,6 +38,7 @@ export default function GenericGadgetRenderer({
   setPodStreamsConnected,
   imageName,
   columnMeta,
+  setStreamError,
 }: GenericGadgetRendererProps) {
   const { ig, isConnected } = usePortForward(
     `api/v1/namespaces/gadget/pods/${podSelected}/portforward?ports=8080`
@@ -46,6 +48,7 @@ export default function GenericGadgetRenderer({
   const attachTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attachStopRef = useRef<{ stop?: () => void } | null>(null);
   const mountedRef = useRef(true);
+  const wasConnectedRef = useRef(false);
   const decodedImageName = decodeURIComponent(imageName || '');
   function gadgetStartStopHandler() {
     if (!ig) return;
@@ -58,7 +61,8 @@ export default function GenericGadgetRenderer({
       setGadgetData,
       setBufferedGadgetData,
       prepareGadgetInfo,
-      columnMeta
+      columnMeta,
+      setStreamError
     );
     if (gadgetInstance) {
       // Clear any pending attachment timeout
@@ -101,7 +105,10 @@ export default function GenericGadgetRenderer({
             }
           },
         },
-        err => console.error('Gadget run error:', err)
+        err => {
+          console.error('Gadget run error:', err);
+          setStreamError?.(String(err));
+        }
       );
     }
   }
@@ -111,6 +118,15 @@ export default function GenericGadgetRenderer({
       setPodStreamsConnected(prev => (podsSelected.length < prev + 1 ? prev : prev + 1));
     }
   }, [isConnected, podsSelected.length, setPodStreamsConnected]);
+
+  useEffect(() => {
+    if (isConnected) {
+      wasConnectedRef.current = true;
+    } else if (wasConnectedRef.current && gadgetRunningStatus) {
+      setStreamError?.('Connection to gadget pod lost');
+      wasConnectedRef.current = false;
+    }
+  }, [isConnected, gadgetRunningStatus]);
 
   useEffect(() => {
     setLoading(false);

--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -107,7 +107,7 @@ export default function GenericGadgetRenderer({
         },
         err => {
           console.error('Gadget run error:', err);
-          setStreamError?.(String(err));
+          setStreamError?.(err instanceof Error ? err.message : JSON.stringify(err));
         }
       );
     }

--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -123,10 +123,15 @@ export default function GenericGadgetRenderer({
     if (isConnected) {
       wasConnectedRef.current = true;
     } else if (wasConnectedRef.current && gadgetRunningStatus) {
-      setStreamError?.('Connection to gadget pod lost');
+      const identifier = podSelected || node;
+      setStreamError?.(
+        identifier
+          ? `Connection to gadget pod lost: ${identifier}`
+          : 'Connection to gadget pod lost'
+      );
       wasConnectedRef.current = false;
     }
-  }, [isConnected, gadgetRunningStatus]);
+  }, [isConnected, gadgetRunningStatus, podSelected, node]);
 
   useEffect(() => {
     setLoading(false);

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -1,7 +1,7 @@
 import { ConfirmDialog, Loader, SectionBox } from '@kinvolk/headlamp-plugin/lib/components/common';
 import K8s from '@kinvolk/headlamp-plugin/lib/k8s';
 import { getCluster, getClusterPrefixedPath } from '@kinvolk/headlamp-plugin/lib/Utils';
-import { Box, Typography } from '@mui/material';
+import { Alert, Box, Typography } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';
 import { generatePath, useHistory, useParams } from 'react-router-dom';
 import { GadgetContext, useGadgetState } from '../common/GadgetContext';
@@ -85,6 +85,7 @@ function GadgetRenderer({
     ...otherState
   } = useContext(GadgetContext);
   const [error, setError] = useState(null);
+  const [streamError, setStreamError] = useState<string | null>(null);
   // Track whether we've made the gadget info request
   const [infoRequested, setInfoRequested] = useState(false);
   const history = useHistory();
@@ -145,11 +146,13 @@ function GadgetRenderer({
 
   function headlessGadgetRunCallback() {
     // i am trying to run now what's my embedded state, also this is a run in background callback so i now isHeadless is true
+    setStreamError(null);
     otherState.setGadgetRunningStatus(true);
     updateInstanceFromStorage(id, embedView, true);
   }
 
   const handleRun = () => {
+    setStreamError(null);
     // but lets first check if it's not enableHistoricalData and embedView is not None
     // if embedView is not None we need to set the instance as embedded
     if (embedView !== 'None' && !enableHistoricalData) {
@@ -323,8 +326,17 @@ function GadgetRenderer({
               podStreamsConnected={podStreamsConnected}
               setPodStreamsConnected={setPodStreamsConnected}
               imageName={imageName}
+              setStreamError={setStreamError}
             />
           ))}
+
+        {streamError && (
+          <Box mt={1}>
+            <Alert severity="error" onClose={() => setStreamError(null)}>
+              Gadget stream error: {streamError}
+            </Alert>
+          </Box>
+        )}
 
         {error ? (
           <Typography variant="body1" color="error">

--- a/src/gadgets/igSocket.tsx
+++ b/src/gadgets/igSocket.tsx
@@ -262,7 +262,7 @@ const usePortForward = (url: string | null): PortForwardState => {
 
         socketRef.current[url] = socket;
 
-        // Directly watch the raw WebSocket close/error events.
+        // Directly watch the raw WebSocket close event.
         // wrapWebSocket's onClose is only called for IG protocol-level events;
         // it does NOT fire when the underlying transport drops (pod deleted, network
         // failure, etc.). This listener catches those transport-level closures so
@@ -275,6 +275,7 @@ const usePortForward = (url: string | null): PortForwardState => {
               ig: null,
               error: new Error('Connection to gadget pod lost'),
             }));
+            cleanup(url);
           }
         });
 

--- a/src/gadgets/igSocket.tsx
+++ b/src/gadgets/igSocket.tsx
@@ -155,7 +155,7 @@ const usePortForward = (url: string | null): PortForwardState => {
   /**
    * Cleans up resources for a specific URL
    */
-  const cleanup = useCallback((targetUrl: string) => {
+  const cleanup = useCallback((targetUrl: string, error?: Error) => {
     // Close and cleanup WebSocket
     if (socketRef.current[targetUrl]) {
       socketRef.current[targetUrl].close();
@@ -174,7 +174,7 @@ const usePortForward = (url: string | null): PortForwardState => {
         ...prev,
         isConnected: false,
         ig: null,
-        error: undefined,
+        error,
       }));
     }
   }, []);
@@ -214,7 +214,7 @@ const usePortForward = (url: string | null): PortForwardState => {
     return () => {
       mountedRef.current = false;
       // Cleanup all connections on unmount
-      Object.keys(socketRef.current).forEach(cleanup);
+      Object.keys(socketRef.current).forEach(key => cleanup(key));
     };
   }, [cleanup]);
 
@@ -229,7 +229,7 @@ const usePortForward = (url: string | null): PortForwardState => {
         isConnected: false,
         error: undefined,
       });
-      Object.keys(socketRef.current).forEach(cleanup);
+      Object.keys(socketRef.current).forEach(key => cleanup(key));
       return;
     }
 
@@ -269,13 +269,7 @@ const usePortForward = (url: string | null): PortForwardState => {
         // isConnected correctly reflects the actual connection state.
         socket.addEventListener('close', () => {
           if (isCurrentRequest && mountedRef.current) {
-            setState(prev => ({
-              ...prev,
-              isConnected: false,
-              ig: null,
-              error: new Error('Connection to gadget pod lost'),
-            }));
-            cleanup(url);
+            cleanup(url, new Error('Connection to gadget pod lost'));
           }
         });
 

--- a/src/gadgets/igSocket.tsx
+++ b/src/gadgets/igSocket.tsx
@@ -262,6 +262,22 @@ const usePortForward = (url: string | null): PortForwardState => {
 
         socketRef.current[url] = socket;
 
+        // Directly watch the raw WebSocket close/error events.
+        // wrapWebSocket's onClose is only called for IG protocol-level events;
+        // it does NOT fire when the underlying transport drops (pod deleted, network
+        // failure, etc.). This listener catches those transport-level closures so
+        // isConnected correctly reflects the actual connection state.
+        socket.addEventListener('close', () => {
+          if (isCurrentRequest && mountedRef.current) {
+            setState(prev => ({
+              ...prev,
+              isConnected: false,
+              ig: null,
+              error: new Error('Connection to gadget pod lost'),
+            }));
+          }
+        });
+
         // Initialize IG connection
         const igConnection = (window as any).wrapWebSocket(socket, {
           onReady: () => {

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -17,7 +17,7 @@ import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '.
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
 import usePortForward from './igSocket';
-import { AllColumnMeta, processGadgetData, getSortedColumns } from './utility';
+import { AllColumnMeta, getSortedColumns, processGadgetData } from './utility';
 
 function getGadgetPodForThisResourceNode(node, pods) {
   if (!node || !pods) return null;

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -150,13 +150,17 @@ export const createGadgetCallbacks = (
   setGadgetData: React.Dispatch<React.SetStateAction<Record<string, any>>>,
   setBufferedGadgetData: React.Dispatch<React.SetStateAction<Record<string, any[]>>>,
   prepareGadgetInfo?: (info: any) => void,
-  columnMeta?: AllColumnMeta
+  columnMeta?: AllColumnMeta,
+  onStreamError?: (msg: string) => void
 ) => {
   return {
     onGadgetInfo: prepareGadgetInfo || (() => { }),
     onReady: () => setLoading(false),
     onDone: () => setLoading(false),
-    onError: (error: any) => console.error('Gadget error:', error),
+    onError: (error: any) => {
+      console.error('Gadget error:', error);
+      onStreamError?.(String(error));
+    },
     onData: (dsID: string, dataFromGadget: any) => {
       const dataToProcess = Array.isArray(dataFromGadget) ? dataFromGadget : [dataFromGadget];
       setLoading(false);

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -9,7 +9,10 @@ export type FieldMeta = { type?: string; annotations?: Record<string, string> };
 export type ColumnMeta = Record<string, FieldMeta>;
 export type AllColumnMeta = Record<string, ColumnMeta>;
 
-export function getSortedColumns(columns: string[], annotations?: Record<string, string>): string[] {
+export function getSortedColumns(
+  columns: string[],
+  annotations?: Record<string, string>
+): string[] {
   const preferredOrderStr = annotations?.['columns'];
   if (preferredOrderStr) {
     const preferredOrder = preferredOrderStr.split(',').map(s => s.trim());
@@ -114,12 +117,12 @@ export const processGadgetData = (
   const massagedData: Record<string, any> = columns.includes(IS_METRIC)
     ? data
     : columns.reduce((acc, column) => {
-      const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
-      if (processedValue !== null) {
-        acc[column] = processedValue;
-      }
-      return acc;
-    }, {});
+        const processedValue = processDataColumn(data, column, columnMetaForDs?.[column]);
+        if (processedValue !== null) {
+          acc[column] = processedValue;
+        }
+        return acc;
+      }, {});
 
   if (columns.includes(IS_METRIC)) {
     setBufferedGadgetData(prevData => ({
@@ -154,7 +157,7 @@ export const createGadgetCallbacks = (
   onStreamError?: (msg: string) => void
 ) => {
   return {
-    onGadgetInfo: prepareGadgetInfo || (() => { }),
+    onGadgetInfo: prepareGadgetInfo || (() => {}),
     onReady: () => setLoading(false),
     onDone: () => setLoading(false),
     onError: (error: any) => {

--- a/src/gadgets/utility.tsx
+++ b/src/gadgets/utility.tsx
@@ -162,7 +162,7 @@ export const createGadgetCallbacks = (
     onDone: () => setLoading(false),
     onError: (error: any) => {
       console.error('Gadget error:', error);
-      onStreamError?.(String(error));
+      onStreamError?.(error instanceof Error ? error.message : JSON.stringify(error));
     },
     onData: (dsID: string, dataFromGadget: any) => {
       const dataToProcess = Array.isArray(dataFromGadget) ? dataFromGadget : [dataFromGadget];


### PR DESCRIPTION
**Description:**
If the gadget connection drops mid-stream (pod deleted, network issue, etc.), the UI used to just freeze while still showing “Running.”

I added a dismissible inline alert on the Gadget Details page so users immediately know the stream has failed instead of guessing.

**Changes:**

* Listen for WebSocket `close` events to catch dropped connections
* Pass a `setStreamError` callback through the renderer
* Show a MUI alert on error (auto-clears on next Start)

**Before/After:**

* Before: table frozen, still “Running,” no error

<img width="1600" height="850" alt="image" src="https://github.com/user-attachments/assets/be1e49a3-bb99-422b-89bb-51ccd58d0f13" />

* After: clear “stream error” alert shown

<img width="1600" height="850" alt="image" src="https://github.com/user-attachments/assets/4af84a9e-fff0-42ef-9806-6f201f82e604" />

