### PR TITLE
fix: limit pod queries using label selectors and dynamically resolve IG daemonset namespaces

### DIFF
--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -6,6 +6,7 @@ interface GenericGadgetRendererProps {
   podsSelected: string[];
   podStreamsConnected: number;
   podSelected: string;
+  podSelectedNamespace?: string;
   setGadgetConfig: (config: any) => void;
   dataColumns: Record<string, string[]>;
   gadgetRunningStatus: boolean;
@@ -25,6 +26,7 @@ export default function GenericGadgetRenderer({
   podsSelected,
   podStreamsConnected,
   podSelected,
+  podSelectedNamespace,
   dataColumns,
   gadgetRunningStatus,
   filters,
@@ -39,7 +41,9 @@ export default function GenericGadgetRenderer({
   columnMeta,
 }: GenericGadgetRendererProps) {
   const { ig, isConnected } = usePortForward(
-    `api/v1/namespaces/gadget/pods/${podSelected}/portforward?ports=8080`
+    `api/v1/namespaces/${
+      podSelectedNamespace || 'gadget'
+    }/pods/${podSelected}/portforward?ports=8080`
   );
   const gadgetRef = useRef<any>(null);
   const gadgetRunningStatusRef = useRef(gadgetRunningStatus);

--- a/src/common/NodeSelection/index.tsx
+++ b/src/common/NodeSelection/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { isIGPod } from '../../gadgets/helper';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from '../../gadgets/helper';
 
 // Improved type definitions
 interface Node {
@@ -61,8 +62,10 @@ interface NodeSelectionProps {
 }
 
 export function NodeSelection(props: NodeSelectionProps) {
-  const [nodes] = K8s.ResourceClasses.Node.useList();
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [nodes] = K8s.ResourceClasses.Node.useList() as unknown as [Node[], any];
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  }) as unknown as [Pod[], any];
   const [finalNodes, setFinalNodes] = useState<Node[]>(null);
   const {
     setPodsSelected,

--- a/src/common/gadgetbackgroundinstanceform.tsx
+++ b/src/common/gadgetbackgroundinstanceform.tsx
@@ -14,6 +14,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { useGadgetConn } from '../gadgets/conn';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from '../gadgets/helper';
 import { generateRandomString } from './helpers';
 
 interface InstanceConfig {
@@ -63,7 +64,9 @@ export function GadgetBackgroundInstanceForm({
   const { enqueueSnackbar } = useSnackbar();
   const { imageName } = useParams<{ imageName: string }>();
   const [nodes] = K8s.ResourceClasses.Node.useList();
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const ig = useGadgetConn(nodes, pods);
   const cluster = getCluster();
 

--- a/src/gadgets/backgroundgadgets.tsx
+++ b/src/gadgets/backgroundgadgets.tsx
@@ -14,10 +14,13 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { IGNotFound } from '../common/NotFound';
 import { isIGInstalled, useGadgetConn } from './conn';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './helper';
 
 export function BackgroundRunning({ embedDialogOpen = false }) {
   const [nodes] = K8s.ResourceClasses.Node.useList();
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const [runningInstances, setRunningInstances] = React.useState<any[] | null>(null);
   const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
   const [tableInstance, setTableInstance] = useState<any>(null);

--- a/src/gadgets/conn.tsx
+++ b/src/gadgets/conn.tsx
@@ -24,7 +24,7 @@ export function useGadgetConn(nodes: any | any[] | null, pods: any[] | null) {
     }
     const url =
       pod && isIGInstalled(pods)
-        ? `api/v1/namespaces/gadget/pods/${pod.jsonData.metadata.name}/portforward?ports=8080`
+        ? `api/v1/namespaces/${pod.jsonData.metadata.namespace}/pods/${pod.jsonData.metadata.name}/portforward?ports=8080`
         : null;
     setPortForwardUrl(url);
   }, [nodes, pods]);

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -11,10 +11,13 @@ import GenericGadgetRenderer from '../common/GenericGadgetRenderer';
 import { generateRandomString, updateInstanceFromStorage } from '../common/helpers';
 import { NodeSelection } from '../common/NodeSelection';
 import { useGadgetConn } from './conn';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './helper';
 
 export function GadgetDetails() {
   const [nodes] = K8s.ResourceClasses.Node.useList();
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const gadgetState = useGadgetState();
 
   if (nodes === null || pods === null) {
@@ -319,6 +322,7 @@ function GadgetRenderer({
               podsSelected={podsSelected}
               node={podSelected?.spec.nodeName}
               podSelected={podSelected?.jsonData.metadata.name}
+              podSelectedNamespace={podSelected?.jsonData.metadata.namespace}
               dataColumns={dataColumns}
               podStreamsConnected={podStreamsConnected}
               setPodStreamsConnected={setPodStreamsConnected}

--- a/src/gadgets/gadgetGrid.tsx
+++ b/src/gadgets/gadgetGrid.tsx
@@ -31,6 +31,7 @@ import { GadgetBackgroundInstanceForm } from '../common/gadgetbackgroundinstance
 import { generateRandomString } from '../common/helpers';
 import { useGadgetConn } from './conn';
 import GadgetFilters from './gadgetFilters';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './helper';
 
 // ... (keep existing imports)
 
@@ -40,7 +41,9 @@ const KUBERNETES_VIEWS = [
 ];
 
 export function GadgetCardEmbedWrapper({ gadget, embedDialogOpen, onClose, resource = null }) {
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const [nodes] = K8s.ResourceClasses.Node.useList();
   const ig = useGadgetConn(nodes, pods);
   const [open, setOpen] = useState(embedDialogOpen);
@@ -526,7 +529,9 @@ const GadgetGrid = ({ gadgets, onEmbedClick, resource = null }) => {
 };
 
 const RunGadgetPanel = ({ gadget, resource }) => {
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const [nodes] = K8s.ResourceClasses.Node.useList();
   if (!gadget) return null;
 

--- a/src/gadgets/list.tsx
+++ b/src/gadgets/list.tsx
@@ -4,9 +4,12 @@ import { Box } from '@mui/material';
 import { IGNotFound } from '../common/NotFound';
 import Gadget from '.';
 import { isIGInstalled } from './conn';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './helper';
 
 export default function GadgetList() {
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const isIGInstallationFound = isIGInstalled(pods);
 
   if (pods === null) {

--- a/src/gadgets/params/filter.tsx
+++ b/src/gadgets/params/filter.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
-import { DataSource } from 'src/types';
+import { DataSource } from '../../types';
 // Assuming you've converted the Title component to React
 
 const operations = [

--- a/src/gadgets/params/k8sfilter.tsx
+++ b/src/gadgets/params/k8sfilter.tsx
@@ -119,12 +119,12 @@ const K8sFilterComponent: React.FC<K8sFilterProps> = ({ param, config, namespace
     kind === 'namespace'
       ? 'Select namespaces...'
       : kind === 'pod'
-        ? 'Select pods...'
-        : kind === 'labels'
-          ? 'Select labels...'
-          : kind === 'container'
-            ? 'Select containers...'
-            : 'Select values...';
+      ? 'Select pods...'
+      : kind === 'labels'
+      ? 'Select labels...'
+      : kind === 'container'
+      ? 'Select containers...'
+      : 'Select values...';
 
   return (
     <Box my={1}>
@@ -150,8 +150,9 @@ const K8sFilterComponent: React.FC<K8sFilterProps> = ({ param, config, namespace
             {...params}
             label={param.title || param.key}
             placeholder={placeholder}
-            helperText={`Kubernetes ${kind + (kind.endsWith('s') ? '' : 's')
-              } to filter on. Supports ! negation.`}
+            helperText={`Kubernetes ${
+              kind + (kind.endsWith('s') ? '' : 's')
+            } to filter on. Supports ! negation.`}
           />
         )}
       />

--- a/src/gadgets/params/k8sfilter.tsx
+++ b/src/gadgets/params/k8sfilter.tsx
@@ -29,7 +29,7 @@ const K8sFilterComponent: React.FC<K8sFilterProps> = ({ param, config, namespace
   const [inputValue, setInputValue] = useState('');
   const [rawValue, setRawValue] = useState('');
   const [namespaces] = K8s.ResourceClasses.Namespace.useList();
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({ namespace: namespace || undefined });
 
   useEffect(() => {
     console.log(kind, namespace, pod, config.get());
@@ -119,12 +119,12 @@ const K8sFilterComponent: React.FC<K8sFilterProps> = ({ param, config, namespace
     kind === 'namespace'
       ? 'Select namespaces...'
       : kind === 'pod'
-      ? 'Select pods...'
-      : kind === 'labels'
-      ? 'Select labels...'
-      : kind === 'container'
-      ? 'Select containers...'
-      : 'Select values...';
+        ? 'Select pods...'
+        : kind === 'labels'
+          ? 'Select labels...'
+          : kind === 'container'
+            ? 'Select containers...'
+            : 'Select values...';
 
   return (
     <Box my={1}>
@@ -150,9 +150,8 @@ const K8sFilterComponent: React.FC<K8sFilterProps> = ({ param, config, namespace
             {...params}
             label={param.title || param.key}
             placeholder={placeholder}
-            helperText={`Kubernetes ${
-              kind + (kind.endsWith('s') ? '' : 's')
-            } to filter on. Supports ! negation.`}
+            helperText={`Kubernetes ${kind + (kind.endsWith('s') ? '' : 's')
+              } to filter on. Supports ! negation.`}
           />
         )}
       />

--- a/src/gadgets/params/sortingfilter.tsx
+++ b/src/gadgets/params/sortingfilter.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@iconify/react';
 import { Box, Button, IconButton, MenuItem, Select, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
-import { DataSource } from 'src/types';
+import { DataSource } from '../../types';
 import Title from './title'; // Assuming you've converted the Title component to React
 
 const SortingFilter = ({ param, config, gadgetConfig }) => {

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../common/helpers';
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './helper';
 import usePortForward from './igSocket';
 import { AllColumnMeta, getSortedColumns, processGadgetData } from './utility';
 
@@ -26,7 +27,9 @@ function getGadgetPodForThisResourceNode(node, pods) {
 }
 
 const RunningGadgetsForResource = ({ resource, open }) => {
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
   const [gadgetInstances, setGadgetInstances] = useState<any[] | null>(null);
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
   const [instanceToDelete, setInstanceToDelete] = useState<string | null>(null);
@@ -39,7 +42,7 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const matchingGadgetPodForThisResourceNode = getGadgetPodForThisResourceNode(node, pods);
   const { ig } = usePortForward(
     matchingGadgetPodForThisResourceNode
-      ? `api/v1/namespaces/gadget/pods/${matchingGadgetPodForThisResourceNode?.jsonData.metadata.name}/portforward?ports=8080`
+      ? `api/v1/namespaces/${matchingGadgetPodForThisResourceNode.jsonData.metadata.namespace}/pods/${matchingGadgetPodForThisResourceNode.jsonData.metadata.name}/portforward?ports=8080`
       : ''
   );
   const cluster = getCluster();
@@ -108,8 +111,7 @@ const RunningGadgetsForResource = ({ resource, open }) => {
         },
         (err: Error) => {
           enqueueSnackbar(
-            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${
-              err?.message ?? String(err)
+            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${err?.message ?? String(err)
             }`,
             { variant: 'error' }
           );

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -111,7 +111,8 @@ const RunningGadgetsForResource = ({ resource, open }) => {
         },
         (err: Error) => {
           enqueueSnackbar(
-            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${err?.message ?? String(err)
+            `Failed to delete "${instance.name || instanceToDelete.slice(-8)}": ${
+              err?.message ?? String(err)
             }`,
             { variant: 'error' }
           );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ import { IGNotFound } from './common/NotFound';
 import { GadgetCreation } from './gadgets/gadgetcreationinresource';
 import { GadgetDetails } from './gadgets/gadgetDetails';
 import { isIGPod } from './gadgets/helper';
+import { IG_CONTAINER_KEY, IG_CONTAINER_VALUE } from './gadgets/helper';
 import GadgetList from './gadgets/list';
 import RunningGadgetsForResource from './gadgets/resourcegadgets';
 
@@ -55,7 +56,9 @@ registerDetailsViewSection(({ resource }: DetailsViewSectionProps) => {
   const embeddedResources = JSON.parse(localStorage.getItem('headlamp_embeded_resources') || '[]');
   const [open, setOpen] = useState(false);
   const isResourceEmbedded = embeddedResources.find((r: any) => r.kind === resource?.jsonData.kind);
-  const [pods] = K8s.ResourceClasses.Pod.useList();
+  const [pods] = K8s.ResourceClasses.Pod.useList({
+    labelSelector: `${IG_CONTAINER_KEY}=${IG_CONTAINER_VALUE}`,
+  });
 
   const isIGInstalled = pods?.find((pod: any) => isIGPod(pod));
 


### PR DESCRIPTION
 fixes #88 

This PR heavily optimizes how the plugin queries Kubernetes for Inspektor Gadget pods, directly fixing issue #88. Previously, the plugin called `K8s.ResourceClasses.Pod.useList()` without any filters across multiple components (including the globally injected resource details view). In large clusters, querying the entire cluster's pod list on every single resource page navigation caused severe network latency, excessive memory overhead, and unneeded load on the `kube-apiserver`. 

To solve this, all instances of Pod.useList() have been updated to include a labelSelector filter targeting the k8s-app=gadget label (utilizing existing IG_CONTAINER_KEY and IG_CONTAINER_VALUE constants). 

Additionally, this PR removes the hardcoded [headlamp-plugin/src/common/GenericGadgetRenderer/index.tsx:53:2-110:3) namespace assumption when establishing port-forward connections. The plugin now dynamically reads the namespace directly from the retrieved pod metadata (`pod.jsonData.metadata.namespace`), ensuring robust compatibility with custom namespace deployments of Inspektor Gadget.

## How to use

1. Run Headlamp with the modified plugin linked/installed against an active cluster.
2. Ensure you have Inspektor Gadget running in the cluster (in the [gadget](headlamp-plugin/src/common/GenericGadgetRenderer/index.tsx:53:2-110:3) namespace or a custom one).
3. Navigate to a cluster resource view (e.g., a Deployment or Node details page). 
4. Open the browser's Developer Tools Network tab and verify that the `GET /api/v1/pods` request now correctly scopes the query using the `?labelSelector=k8s-app%3Dgadget` parameter, returning a significantly smaller JSON payload.
5. Verify that port-forwarding metrics and gadgets establish a connection and load correctly in the resource details section.

## Testing done

Executed local testing of the Headlamp UI to ensure the websocket port-forward connections start correctly under the new dynamic namespace logic. Also ran the automated code quality suite:

```bash
# Formatted the codebase
npm run format

# Verified TypeScript typings and linting
npm run tsc && npm run lint

# Built the final distributions
npm run build
