### PR TITLE
fix(api): dynamically resolve backend URL for in-cluster deployments.

### DIFF
--- a/src/gadgets/helper.ts
+++ b/src/gadgets/helper.ts
@@ -78,5 +78,10 @@ export function getServerURL() {
   if (isDockerDesktop()) {
     return 'http://localhost:64446';
   }
-  return 'http://localhost:4466';
+  if (isElectron()) {
+    return 'http://localhost:4466';
+  }
+  // For standard browser environments (in-cluster), use relative URLs.
+  // Headlamp API proxying will automatically route this traffic correctly.
+  return '';
 }


### PR DESCRIPTION
fixes #102 
# fix: resolve backend API url dynamically from browser origin

The Inspektor Gadget plugin contained an architectural flaw in how it resolved its backend API endpoint. The [getServerURL()](cci:1://file:///Users/utkarshraj/Documents/Lfx/headlamp-plugin/src/gadgets/helper.ts:76:0-86:1) function was hardcoded to return `http://localhost:4466` for all non-Docker Desktop environments. Because of this, when the plugin was used in any standard Kubernetes web deployment (like EKS, GKE, or Bare-metal), it incorrectly attempted to route its internal API traffic to the user's local machine, causing fatal `ERR_CONNECTION_REFUSED` errors when attempting to use any gadgets.

This PR addresses the issue by modifying [getServerURL()](cci:1://file:///Users/utkarshraj/Documents/Lfx/headlamp-plugin/src/gadgets/helper.ts:76:0-86:1) to accurately check for the desktop application environments ([isDockerDesktop()](cci:1://file:///Users/utkarshraj/Documents/Lfx/headlamp-plugin/src/gadgets/helper.ts:68:0-74:1) and [isElectron()](cci:1://file:///Users/utkarshraj/Documents/Lfx/headlamp-plugin/src/gadgets/helper.ts:38:0-66:1)), and safely returning an empty string `""` for everything else (in-cluster browser clients). 

By returning an empty string, we allow the [fetch](cci:1://file:///Users/utkarshraj/Documents/Lfx/headlamp/frontend/src/components/App/Layout.tsx:131:0-182:2) and `WebSocket` calls across the plugin codebase to safely resolve via relative paths. This empowers Headlamp's environment-aware API proxying to correctly route the traffic straight into the backend service regardless of the deployment configuration.

## How to use

Reviewers can validate this PR by doing the following:
1. Deploy Headlamp with this plugin branch built into a remote Kubernetes cluster. 
2. Access the Headlamp UI in your browser via the remote domain or IP.
3. Navigate to the "Gadgets" or "Resource Gadgets" section and attempt to attach or run a gadget instance.
4. Verify that the browser network tab successfully connects to `/plugins/.../` or `/externalproxy` endpoints without throwing `ERR_CONNECTION_REFUSED` on `localhost` endpoints, and confirm that the gadget streams data successfully.

## Testing done

All code formatting, linting, and TypeScript compilation CI workflows were successfully validated locally on the branch. Testing outputs are fully green.

```bash
npm run format && npm run lint && npm run tsc && npm run test
