### PR TITLE
feat: allow resource scoped gadget embedding

### DIFF
--- a/src/common/GadgetDescription/index.tsx
+++ b/src/common/GadgetDescription/index.tsx
@@ -31,6 +31,7 @@ export function GadgetDescription({
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState('');
   const { gadgetRunningStatus } = useContext(GadgetContext);
+  const isResourceScoped = !!gadgetInstance?.embeddedResource;
 
   useEffect(() => {
     findGadgetInstance();
@@ -175,36 +176,49 @@ export function GadgetDescription({
                   <FormControlLabel
                     labelPlacement="start"
                     control={
-                      <Select
-                        labelId="embed-type-label"
-                        value={embedView}
-                        size="small"
-                        label="Embed Type"
-                        onChange={e => {
-                          setEmbedView(e.target.value);
-                          const allInstances = JSON.parse(
-                            localStorage.getItem('headlamp_embeded_resources') || '[]'
-                          );
-                          const index = allInstances.findIndex(instance => instance.id === id);
-                          if (index !== -1) {
-                            if (e.target.value !== 'None') {
-                              allInstances[index].isEmbedded = true;
-                            } else {
-                              allInstances[index].isEmbedded = false;
-                            }
-                            allInstances[index].kind = e.target.value;
-                            localStorage.setItem(
-                              'headlamp_embeded_resources',
-                              JSON.stringify(allInstances)
-                            );
-                            setGadgetInstance({ ...gadgetInstance, kind: e.target.value });
-                          }
-                        }}
+                      <Tooltip
+                        title={
+                          isResourceScoped
+                            ? 'This gadget is scoped to a specific resource. To change its embed type, remove it and re-add it from the target resource page.'
+                            : ''
+                        }
+                        disableHoverListener={!isResourceScoped}
                       >
-                        <MenuItem value="None">None</MenuItem>
-                        <MenuItem value="Pod">Pod</MenuItem>
-                        <MenuItem value="Node">Node</MenuItem>
-                      </Select>
+                        {/* A span is needed so Tooltip works on a disabled element */}
+                        <span>
+                          <Select
+                            labelId="embed-type-label"
+                            value={embedView}
+                            size="small"
+                            label="Embed Type"
+                            disabled={isResourceScoped}
+                            onChange={e => {
+                              setEmbedView(e.target.value);
+                              const allInstances = JSON.parse(
+                                localStorage.getItem('headlamp_embeded_resources') || '[]'
+                              );
+                              const index = allInstances.findIndex(instance => instance.id === id);
+                              if (index !== -1) {
+                                if (e.target.value !== 'None') {
+                                  allInstances[index].isEmbedded = true;
+                                } else {
+                                  allInstances[index].isEmbedded = false;
+                                }
+                                allInstances[index].kind = e.target.value;
+                                localStorage.setItem(
+                                  'headlamp_embeded_resources',
+                                  JSON.stringify(allInstances)
+                                );
+                                setGadgetInstance({ ...gadgetInstance, kind: e.target.value });
+                              }
+                            }}
+                          >
+                            <MenuItem value="None">None</MenuItem>
+                            <MenuItem value="Pod">Pod</MenuItem>
+                            <MenuItem value="Node">Node</MenuItem>
+                          </Select>
+                        </span>
+                      </Tooltip>
                     }
                     label={
                       <Box sx={{ display: 'flex', alignItems: 'center', mr: 2 }}>

--- a/src/common/embedScoping.tsx
+++ b/src/common/embedScoping.tsx
@@ -1,0 +1,84 @@
+// Helpers for resource-scoped gadget embedding.
+
+// Reference to a specific K8s resource.
+export interface EmbeddedResourceRef {
+  kind: string;
+  name: string;
+  // Namespace (absent for cluster-scoped resources like Nodes).
+  namespace?: string;
+  cluster: string;
+}
+
+// Stored gadget instance shape.
+export interface GadgetInstance {
+  id: string;
+  cluster: string;
+  kind?: string;
+  isEmbedded?: boolean;
+  isHeadless?: boolean;
+  // Present when bound to a specific resource.
+  embeddedResource?: EmbeddedResourceRef;
+  gadgetConfig?: {
+    imageName: string;
+    version: number;
+    paramValues?: Record<string, any>;
+  };
+  name?: string;
+  tags?: string[];
+}
+
+// Build an EmbeddedResourceRef from resource jsonData.
+export function deriveResourceRef(
+  resourceJson: any,
+  cluster: string
+): EmbeddedResourceRef {
+  const kind: string = resourceJson?.kind ?? '';
+  const name: string = resourceJson?.metadata?.name ?? '';
+  const namespace: string | undefined =
+    resourceJson?.metadata?.namespace ?? undefined;
+
+  return {
+    kind,
+    name,
+    ...(namespace ? { namespace } : {}),
+    cluster,
+  };
+}
+
+// Returns true if the instance matches the resource and cluster.
+export function doesInstanceMatchResource(
+  instance: GadgetInstance,
+  resourceJson: any,
+  cluster: string
+): boolean {
+  if (!instance.isEmbedded) return false;
+  if (!resourceJson) return false;
+
+  const ref = instance.embeddedResource;
+  if (!ref) return false;
+
+  if (ref.cluster !== cluster) return false;
+  if (ref.kind !== resourceJson.kind) return false;
+  if (ref.name !== resourceJson?.metadata?.name) return false;
+
+  const instanceNs = ref.namespace;
+  const resourceNs: string | undefined = resourceJson?.metadata?.namespace;
+
+  if (instanceNs !== undefined || resourceNs !== undefined) {
+    if (instanceNs !== resourceNs) return false;
+  }
+
+  return true;
+}
+
+// Quick existence check: does **any** stored instance match this resource?
+// Used by the section gate in `src/index.tsx` to decide whether to render
+// the Inspektor Gadget section at all.
+export function hasEmbeddedInstancesForResource(
+  instances: GadgetInstance[],
+  resourceJson: any,
+  cluster: string
+): boolean {
+  if (!Array.isArray(instances) || !resourceJson) return false;
+  return instances.some(i => doesInstanceMatchResource(i, resourceJson, cluster));
+}

--- a/src/common/gadgetbackgroundinstanceform.tsx
+++ b/src/common/gadgetbackgroundinstanceform.tsx
@@ -14,6 +14,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { useGadgetConn } from '../gadgets/conn';
+import { deriveResourceRef } from './embedScoping';
 import { generateRandomString } from './helpers';
 
 interface InstanceConfig {
@@ -98,6 +99,11 @@ export function GadgetBackgroundInstanceForm({
       return;
     }
 
+    const hasResourceContext = !!(resource && resource.jsonData);
+    const resourceRef = hasResourceContext
+      ? deriveResourceRef(resource.jsonData, cluster)
+      : undefined;
+
     const newInstance = {
       id: instanceConfig.name + '' + Math.random(),
       name: instanceConfig.name,
@@ -112,7 +118,8 @@ export function GadgetBackgroundInstanceForm({
       cluster: cluster,
       isHeadless: false,
       tags: instanceConfig.tags,
-      isEmbedded: true,
+      isEmbedded: hasResourceContext,
+      ...(resourceRef ? { embeddedResource: resourceRef } : {}),
     };
     if (instanceConfig.runInBackground) {
       // Make a call to ig.createGadgetInstance when Run In Background is checked

--- a/src/common/helpers.tsx
+++ b/src/common/helpers.tsx
@@ -27,11 +27,12 @@ export function updateInstanceFromStorage(
 
     instance.isHeadless = isHeadless; // Update isHeadless property
     if (embedView !== 'None') {
-      instance.kind = embedView; // Update kind with embedView
-      instance.isEmbedded = true; // Mark as embedded
+      instance.kind = embedView;
+      instance.isEmbedded = true;
     } else {
-      delete instance.kind; // Remove kind if embedView is 'None'
-      instance.isEmbedded = false; // Mark as non-embedded
+      delete instance.kind;
+      instance.isEmbedded = false;
+      delete instance.embeddedResource;
     }
     instance.gadgetConfig.paramValues = paramValues; // Update paramValues
 

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -199,6 +199,9 @@ function GadgetRenderer({
             cluster: getCluster(),
             kind: embedView,
             isEmbedded: embedView !== 'None',
+            ...(instance?.embeddedResource
+              ? { embeddedResource: instance.embeddedResource }
+              : {}),
           };
           const updatedEmbeddedInstances = [...updatedInstances, newInstance];
           localStorage.setItem(
@@ -252,6 +255,9 @@ function GadgetRenderer({
               nodes: [],
               cluster: getCluster(),
               isEmbedded: false,
+              ...(instance?.embeddedResource
+                ? { embeddedResource: instance.embeddedResource }
+                : {}),
             },
           ])
         );

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { doesInstanceMatchResource } from '../common/embedScoping';
 import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../common/helpers';
 import { MetricChart } from '../common/MetricChart';
 import { isIGPod } from './helper';
@@ -47,11 +48,11 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const processLocalStorageInstances = useMemo(
     () => localStorageInstances => {
       if (!localStorageInstances) return [];
-      return localStorageInstances
-        .filter(item => item.kind === resource?.jsonData.kind && item.cluster === cluster)
-        .filter(i => i.isEmbedded);
+      return localStorageInstances.filter(item =>
+        doesInstanceMatchResource(item, resource?.jsonData, cluster)
+      );
     },
-    [resource?.jsonData.kind, cluster, open]
+    [resource?.jsonData, cluster, open]
   );
 
   useEffect(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,8 +12,10 @@ import {
 } from '@kinvolk/headlamp-plugin/lib/components/common';
 import { DetailsViewSectionProps } from '@kinvolk/headlamp-plugin/lib/components/DetailsViewSection/DetailsViewSection';
 import K8s from '@kinvolk/headlamp-plugin/lib/k8s';
+import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import { Box, Typography } from '@mui/material';
 import { useState } from 'react';
+import { hasEmbeddedInstancesForResource } from './common/embedScoping';
 import { IGNotFound } from './common/NotFound';
 import { GadgetCreation } from './gadgets/gadgetcreationinresource';
 import { GadgetDetails } from './gadgets/gadgetDetails';
@@ -54,7 +56,12 @@ registerRoute({
 registerDetailsViewSection(({ resource }: DetailsViewSectionProps) => {
   const embeddedResources = JSON.parse(localStorage.getItem('headlamp_embeded_resources') || '[]');
   const [open, setOpen] = useState(false);
-  const isResourceEmbedded = embeddedResources.find((r: any) => r.kind === resource?.jsonData.kind);
+  const cluster = getCluster();
+  const isResourceEmbedded = hasEmbeddedInstancesForResource(
+    embeddedResources,
+    resource?.jsonData,
+    cluster
+  );
   const [pods] = K8s.ResourceClasses.Pod.useList();
 
   const isIGInstalled = pods?.find((pod: any) => isIGPod(pod));


### PR DESCRIPTION
# fix: scope embedded gadgets to specific resource (Pod/Node) only

## Description

When a user embedded a gadget from a Pod or Node details page, the record stored in `localStorage['headlamp_embeded_resources']` only persisted the resource `kind` and `cluster`, no specific resource identity. Every other resource of the same kind in the cluster would then display the gadget, causing visibility leaks, unintended cross-resource sharing, and destructive cross-impact on deletes.

This fix makes the embed system **exclusively resource-scoped**: every embedded gadget is now bound to the exact Pod or Node it was created from. There is no longer a "kind-wide" global embed mode. A new `embeddedResource` field (containing `kind`, `name`, `namespace?`, and `cluster`) is written at creation time and used as the single matching key on the read path. Records without `embeddedResource` (legacy global entries) will not match and are silently not shown.

---

## Implementation Details

### `src/common/embedScoping.tsx`
A self-contained helper module that is the **single source of truth** for all embed-scoping logic. No other file duplicates the matching logic.

- **Types**: `EmbeddedResourceRef`, `GadgetInstance`
- `deriveResourceRef(jsonData, cluster)`: builds a normalized `{ kind, name, namespace?, cluster }` ref from `resource.jsonData`
- `doesInstanceMatchResource(instance, resourceJson, cluster)`: requires `embeddedResource` to be present; matches on kind, name, cluster, and namespace (when applicable). Instances without `embeddedResource` return `false`.
- `hasEmbeddedInstancesForResource(instances, resourceJson, cluster)`: quick existence check used by the section gate

### `src/common/gadgetbackgroundinstanceform.tsx`
When `resource` prop is a real object, the new instance now persists:
```ts
isEmbedded: true,
embeddedResource: { kind, name, namespace?, cluster }
```
When `resource` is absent (fallback path), `isEmbedded` is set to `false` and no `embeddedResource` is written, so it never surfaces in any embed view.

### `src/gadgets/gadgetDetails.tsx`
Both `handleRun` (on-demand → headless) and `deleteHeadlessGadget` (headless → on-demand) rebuild a fresh `localStorage` record. Both now copy `embeddedResource` from the original so the resource binding survives mode transitions.

### `src/common/helpers.tsx`
Preserves `embeddedResource` on all transitions where `embedView !== 'None'`. Clears it (along with `kind` and `isEmbedded`) only when detaching (`embedView === 'None'`).

### Read paths: `src/index.tsx` + `src/gadgets/resourcegadgets.tsx`
- **`index.tsx` gate**: replaced kind-only check with `hasEmbeddedInstancesForResource`; also fixed a pre-existing bug where `cluster` was not checked at the gate level
- **`resourcegadgets.tsx` filter**: replaced two-step kind + cluster filter with `doesInstanceMatchResource`, gate and renderer now use identical logic

### `src/common/GadgetDescription/index.tsx`
The **Embed Type `<Select>`** on the standalone gadget details page is disabled whenever `embeddedResource` is present (i.e., always for new records), with a clear tooltip:
> *"This gadget is scoped to a specific resource. To change its embed type, remove it and re-add it from the target resource page."*

---

## Testing Done

### Before

https://github.com/user-attachments/assets/1517f831-29a4-493a-abb3-6fb7a4c4d781

### After

https://github.com/user-attachments/assets/a5c5bc13-ebbb-4717-8cee-e054f23a0c28

Now, the gadgets are being embedded and managed specific to each pod.

---

## Checklist

+ [x] This PR fixes #105 
+ [x] All the test pass locally
+ [x] I have shared the recording which confirm that the bug has been resolved
+ [x] Commits have been signed-off