### PR TITLE
fix: use dynamic namespace in port-forward URLs instead of hardcoded

### DIFF
--- a/src/common/GenericGadgetRenderer/index.tsx
+++ b/src/common/GenericGadgetRenderer/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { buildPortForwardURL } from '../../gadgets/helper';
 import usePortForward from '../../gadgets/igSocket';
 import { AllColumnMeta, createGadgetCallbacks } from '../../gadgets/utility';
 
@@ -6,6 +7,7 @@ interface GenericGadgetRendererProps {
   podsSelected: string[];
   podStreamsConnected: number;
   podSelected: string;
+  podNamespace: string;
   setGadgetConfig: (config: any) => void;
   dataColumns: Record<string, string[]>;
   gadgetRunningStatus: boolean;
@@ -25,6 +27,7 @@ export default function GenericGadgetRenderer({
   podsSelected,
   podStreamsConnected,
   podSelected,
+  podNamespace,
   dataColumns,
   gadgetRunningStatus,
   filters,
@@ -38,9 +41,7 @@ export default function GenericGadgetRenderer({
   imageName,
   columnMeta,
 }: GenericGadgetRendererProps) {
-  const { ig, isConnected } = usePortForward(
-    `api/v1/namespaces/gadget/pods/${podSelected}/portforward?ports=8080`
-  );
+  const { ig, isConnected } = usePortForward(buildPortForwardURL(podSelected, podNamespace));
   const gadgetRef = useRef<any>(null);
   const gadgetRunningStatusRef = useRef(gadgetRunningStatus);
   const attachTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/gadgets/conn.tsx
+++ b/src/gadgets/conn.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router';
-import { isIGPod } from './helper';
+import { buildPortForwardURL, isIGPod } from './helper';
 import usePortForward from './igSocket';
 
 export function useGadgetConn(nodes: any | any[] | null, pods: any[] | null) {
@@ -24,7 +24,7 @@ export function useGadgetConn(nodes: any | any[] | null, pods: any[] | null) {
     }
     const url =
       pod && isIGInstalled(pods)
-        ? `api/v1/namespaces/gadget/pods/${pod.jsonData.metadata.name}/portforward?ports=8080`
+        ? buildPortForwardURL(pod.jsonData.metadata.name, pod.jsonData.metadata.namespace)
         : null;
     setPortForwardUrl(url);
   }, [nodes, pods]);

--- a/src/gadgets/gadgetDetails.tsx
+++ b/src/gadgets/gadgetDetails.tsx
@@ -319,6 +319,7 @@ function GadgetRenderer({
               podsSelected={podsSelected}
               node={podSelected?.spec.nodeName}
               podSelected={podSelected?.jsonData.metadata.name}
+              podNamespace={podSelected?.jsonData.metadata.namespace}
               dataColumns={dataColumns}
               podStreamsConnected={podStreamsConnected}
               setPodStreamsConnected={setPodStreamsConnected}

--- a/src/gadgets/helper.ts
+++ b/src/gadgets/helper.ts
@@ -78,5 +78,30 @@ export function getServerURL() {
   if (isDockerDesktop()) {
     return 'http://localhost:64446';
   }
-  return 'http://localhost:4466';
+  if (isElectron()) {
+    return 'http://localhost:4466';
+  }
+  // For standard browser environments (in-cluster), use relative URLs.
+  // Headlamp API proxying will automatically route this traffic correctly.
+  return '';
+}
+
+/**
+ * Build a port-forward URL for an Inspektor Gadget pod.
+ *
+ * Derives the namespace dynamically from the pod's own metadata instead of
+ * hardcoding a specific namespace, so the plugin works regardless of where
+ * Inspektor Gadget is installed.
+ *
+ * @param podName - The name of the IG pod.
+ * @param podNamespace - The namespace the IG pod lives in.
+ * @returns The Kubernetes port-forward API path, or `null` when either
+ *          argument is missing.
+ */
+export function buildPortForwardURL(
+  podName: string | undefined | null,
+  podNamespace: string | undefined | null
+): string | null {
+  if (!podName || !podNamespace) return null;
+  return `api/v1/namespaces/${podNamespace}/pods/${podName}/portforward?ports=8080`;
 }

--- a/src/gadgets/resourcegadgets.tsx
+++ b/src/gadgets/resourcegadgets.tsx
@@ -16,7 +16,7 @@ import { useSnackbar } from 'notistack';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { HEADLAMP_KEY, HEADLAMP_METRIC_UNIT, HEADLAMP_VALUE, IS_METRIC } from '../common/helpers';
 import { MetricChart } from '../common/MetricChart';
-import { isIGPod } from './helper';
+import { buildPortForwardURL, isIGPod } from './helper';
 import usePortForward from './igSocket';
 import { AllColumnMeta, getSortedColumns, processGadgetData } from './utility';
 
@@ -39,8 +39,11 @@ const RunningGadgetsForResource = ({ resource, open }) => {
   const matchingGadgetPodForThisResourceNode = getGadgetPodForThisResourceNode(node, pods);
   const { ig } = usePortForward(
     matchingGadgetPodForThisResourceNode
-      ? `api/v1/namespaces/gadget/pods/${matchingGadgetPodForThisResourceNode?.jsonData.metadata.name}/portforward?ports=8080`
-      : ''
+      ? buildPortForwardURL(
+          matchingGadgetPodForThisResourceNode?.jsonData.metadata.name,
+          matchingGadgetPodForThisResourceNode?.jsonData.metadata.namespace
+        )
+      : null
   );
   const cluster = getCluster();
 


### PR DESCRIPTION
fixes #107 

# fix: Use dynamic namespace in port-forward URLs instead of hardcoding `gadget`

Port-forward URLs across the plugin were hardcoded to the `gadget` namespace (e.g. `api/v1/namespaces/gadget/pods/<name>/portforward?ports=8080`). This means the plugin is completely non-functional for any cluster where Inspektor Gadget is installed in a namespace other than `gadget` — for example `kube-system`, `ig-system`, or any custom namespace. The WebSocket connection either returns a `404` from the Kubernetes API server or times out after 10 seconds, and no gadget data is ever displayed.

This PR introduces a `buildPortForwardURL(podName, podNamespace)` helper in `helper.ts` that constructs the port-forward path dynamically from the IG pod's own metadata. All three call sites (`conn.tsx`, `resourcegadgets.tsx`, and `GenericGadgetRenderer/index.tsx`) are updated to use this helper. For `GenericGadgetRenderer`, which previously only received the pod name as a string, a new `podNamespace` prop is added and passed from `gadgetDetails.tsx`.

Additionally, this fixes a secondary bug in `resourcegadgets.tsx` where the fallback value for `usePortForward` was an empty string `''` instead of `null`. Since `usePortForward` only skips connection initialization when the URL is strictly `null`, the empty string caused a bogus WebSocket connection attempt and a 10-second timeout on every render where no IG pod was found for the current node.

## How to use

1. Install Inspektor Gadget into a namespace **other than** `gadget` (e.g. `ig-system`):
   ```bash
   kubectl create namespace ig-system
   helm install gadget gadget/gadget --namespace ig-system

